### PR TITLE
release 0.2.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,3 +123,13 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_GH_TOKEN }}
+
+  release-crates-io:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/checkout@v1
+      - run: cargo login ${CRATES_IO_TOKEN}
+        env:
+          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      - run: cargo publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.2 - (2022-02-14)
+## 0.2.2 - (2022-02-22)
 
 - **Other changes:**
     - Speedup of `DecisisionTreeNode.split_samples` resulting in overall 6 - 20% faster

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/mlondschien/biosphere/"
 readme = "README.md"
 license = "BSD-3-Clause"
 version = "0.2.2"
-edition = "2018"
+edition = "2021"
 exclude = ["/.github", "/changeforest-py", ".pre-commit-config.yaml", ".gitignore"]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Malte Londschien <malte@londschien.ch>"]
 repository = "https://github.com/mlondschien/biosphere/"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 exclude = ["/.github", "/changeforest-py", ".pre-commit-config.yaml", ".gitignore"]
 

--- a/biosphere-py/Cargo.toml
+++ b/biosphere-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biosphere_py"
-version = "0.2.0"
+version = "0.2.2"
 edition = "2018"
 
 [lib]

--- a/biosphere-py/Cargo.toml
+++ b/biosphere-py/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "biosphere_py"
 version = "0.2.2"
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "biosphere"

--- a/biosphere-py/pyproject.toml
+++ b/biosphere-py/pyproject.toml
@@ -2,7 +2,7 @@
 name = "biosphere"
 description = "Simple, fast random forests"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.7"
 author = "Malte Londschien <malte@londschien.ch>"
 urls = {homepage = "https://github.com/mlondschien/biosphere/"}


### PR DESCRIPTION
- Update changelog date.
- Add release ci.
- Bump version numbers.
- Use 2021 edition rust.
