### PR TITLE
Add GPU support

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+settings.local.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       run: cargo build --release --verbose --examples
     - name: Test
       run: cargo test --release
-  
+
   check:
     name: Check
     runs-on: ubuntu-latest
@@ -52,7 +52,7 @@ jobs:
         with:
           command: fmt
           args: --all -- --check  # Also fmt subdirectories
-    
+
   package:
     name: Package (rust)
     runs-on: ubuntu-latest
@@ -100,29 +100,6 @@ jobs:
           cargo bench
         shell: bash -lxeu {0}
 
-  asv-bench:
-    name: ASV Benchmarks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
-
-      - name: Install asv
-        run: |
-          pip install --upgrade asv
-      
-      - name: Run benchmarks
-        run: |
-          cd biosphere-py
-          asv machine --machine github --yes
-          asv continuous origin/main HEAD -e --factor 1.05 --machine github --python=python
-
-  
   python-tests:
     name: Python tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ The `MaxFeatures` enum supports multiple feature sampling strategies:
 
 **What was built:**
 - `src/flat_forest.rs` — `FlatForest` / `FlatNode` / `ForestMeta`: flat tree array for CPU and GPU inference. Nodes in BFS visit order with **explicit child indices** (`left: i32`, `right: i32`; -1 for leaves). `max_tree_size` is the actual max node count across trees (NOT `2^(max_depth+1) - 1`). `FlatForest.meta: ForestMeta` holds the four `u32` dimensions; `FlatForest` impls `Deref<Target = ForestMeta>` for ergonomic access.
-- `src/gpu/pipeline.rs` — `GpuForest`: uploads `FlatForest` nodes **directly** (already `f32`; zero conversion), compiles WGSL pipelines with device-queried workgroup size, runs batched inference via `predict(&[f32], n_samples) -> Vec<f32>`.
+- `src/gpu/pipeline.rs` — `GpuForest`: uploads `FlatForest` nodes **directly** (already `f32`; zero conversion), compiles WGSL pipelines with device-queried workgroup size, runs batched inference via `predict(&ArrayView2<f32>) -> Array1<f32>`.
 - `src/gpu/shaders/traverse.wgsl` — 2D dispatch `(ceil(n_samples/wg_size), n_trees, 1)`, one thread per (sample, tree). Uses `u32(node.left)` / `u32(node.right)` for traversal; `max_depth` is the GPU loop safety bound.
 - `src/gpu/shaders/reduce.wgsl` — averages per-tree predictions per sample.
 - Tests: `tests/flat_forest.rs` (CPU, no feature flag), `tests/gpu_inference.rs` (requires GPU, `--features gpu`).
@@ -71,14 +71,20 @@ left: i32 | right: i32 | feature_index: u32 | value: f32
 `value` is dual-purpose: split threshold for internal nodes, leaf prediction for leaves. `left < 0` is the sole discriminant — no separate `is_leaf` field needed. 16 bytes = exactly 4 nodes per 64-byte cache line. Under `gpu` feature, `FlatNode` and `ForestMeta` derive `bytemuck::Pod + Zeroable`, so nodes upload as `bytemuck::cast_slice::<FlatNode, u8>(&flat.nodes)` with no conversion loop.
 
 **Precision model:**
-- `FlatNode` stores `value: f32`. `FlatForest::predict` casts each feature to `f32` before comparison so that CPU and GPU traversal are identical.
+- `FlatNode` stores `value: f32`. `FlatForest::predict` takes `&ArrayView2<f32>` directly — no per-split cast. `GpuForest::predict` also takes `&ArrayView2<f32>`. Both CPU and GPU traversal are therefore identical.
 - `FlatForest::predict` results differ from `RandomForest::predict` (f64) by ~1e-5 due to f32 quantisation of leaf values; use that tolerance in tests.
 - `FlatForest::predict` vs `GpuForest::predict` differ by <1e-5 (only f64 vs f32 accumulation of f32 leaf values).
+- Callers convert f64 training data once with `X.mapv(|v| v as f32)` before calling either predict.
+
+**FlatForest::predict_one loop bound:**
+Uses `0..=self.meta.max_depth` (inclusive), not `max_tree_size`. This matches the GPU shader and gives the compiler a tight, small bound (e.g. 9 iterations for depth-8 trees), enabling better optimisation. `max_depth` is computed by `node_depth()` during `from_forest` — it is the actual maximum depth across all trees, so `max_depth + 1` iterations always suffice to reach any leaf.
 
 **GpuForest API (wgpu 28):**
 - `GpuForest::from_flat_forest(flat: &FlatForest, max_samples: usize) -> GpuForest` — creates GPU buffers sized for up to `max_samples` rows. Pre-allocates 4 buffers at init; no per-call VRAM allocation.
 - `GpuForest::fork(&self, max_samples: usize) -> GpuForest` — clones the `Arc<GpuForestShared>` (device, queue, pipelines, static node/meta buffers) and allocates fresh per-instance buffers. Use this to get per-thread handles without recompiling shaders or re-uploading node data.
-- `GpuForest::predict(features: &[f32], n_samples: usize) -> Vec<f32>` — writes features via `queue.write_buffer`, creates sub-range bind groups so `arrayLength()` in the shader sees `n_samples` (not `max_samples`), submits, waits with `device.poll(PollType::Wait { submission_index: Some(idx), timeout: None })`, reads staging buffer, calls `staging_buffer.unmap()`.
+- `GpuForest::predict(&ArrayView2<f32>) -> Array1<f32>` — calls `predict_submit` then `collect`. Uses `X.as_standard_layout()` internally to get a contiguous slice (zero-copy if already C-order).
+- `GpuForest::predict_submit(&ArrayView2<f32>) -> Option<PredictHandle<'_>>` — submits GPU work immediately; returns `None` for empty input. `PredictHandle::collect() -> Array1<f32>` blocks until done. Use submit+collect to overlap GPU work across multiple forests.
+- Writes features via `queue.write_buffer`, creates sub-range bind groups so `arrayLength()` in the shader sees `n_samples` (not `max_samples`), submits, waits with `device.poll(PollType::Wait { submission_index: Some(idx), timeout: None })`, reads staging buffer, calls `staging_buffer.unmap()`.
 - Sub-range binding: pass `wgpu::BufferBinding { buffer, offset: 0, size: Some(BufferSize::new(feature_bytes)) }` — this is essential for `arrayLength()` to reflect the actual batch size, not buffer capacity.
 - wgpu 28 poll API: `queue.submit()` returns a `SubmissionIndex`; pass it to `device.poll(PollType::Wait { submission_index: Some(idx), timeout: None })` for per-submission blocking wait.
 - Always call `staging_buffer.unmap()` after reading from a pre-allocated (reused) staging buffer, so the next `encoder.copy_buffer_to_buffer` + map cycle works correctly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,6 @@
-# Information for Coding Agents
-
 Biosphere is a Rust library for fast and simple Random Forests.
 
-## Project Overview
+# Project Overview
 
 The repository consists of:
 - **Rust core library** (`src/`): Core random forest and decision tree implementation
@@ -55,11 +53,24 @@ The `MaxFeatures` enum supports multiple feature sampling strategies:
 - `Fraction(f64)`: Use fraction of features
 - `Sqrt`: Use sqrt(n_features)
 
-# Agent Instructions
+## GPU Feature (`--features gpu`)
+
+**What was built:**
+- `src/flat_forest.rs` — `FlatForest` / `FlatNode`: BFS-encoded flat tree array usable for both CPU and GPU inference. `FlatForest::from_forest(forest, n_features)` flattens all trees (padded to uniform `max_tree_size = 2^(max_depth+1) - 1`). `FlatForest::predict` matches `RandomForest::predict` exactly.
+- `src/gpu/pipeline.rs` — `GpuForest`: uploads `FlatForest` to GPU (f64→f32), compiles WGSL pipelines, runs batched inference via `predict(&[f32], n_samples) -> Vec<f32>`.
+- `src/gpu/shaders/traverse.wgsl` — 2D dispatch `(ceil(n_samples/64), n_trees, 1)`, one thread per (sample, tree).
+- `src/gpu/shaders/reduce.wgsl` — averages per-tree predictions per sample.
+- Tests: `tests/flat_forest.rs` (CPU, no feature flag), `tests/gpu_inference.rs` (requires GPU, `--features gpu`).
+
+## Known pre-existing issue
+
+The debug assertion in `decision_tree_node.rs:180` fires for random training sets > ~300 samples — keep test training sizes ≤ 200 samples.
+
+# Memory
 
 **Keep this file updated.** After every session where you discover something stable and non-obvious about this project, add it below. Remove or correct entries that turn out to be wrong or outdated. Do not duplicate entries already in CLAUDE.md.
 
-## Interactivity guidelines
+# Interactivity guidelines
 
 When you are asked to implement something, always ask for clarifications if needed.
 If you are unsure about the requirements, ask for more details.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,13 +81,24 @@ Uses `0..=self.meta.max_depth` (inclusive), not `max_tree_size`. This matches th
 
 **GpuForest API (wgpu 28):**
 - `GpuForest::from_flat_forest(flat: &FlatForest, max_samples: usize) -> GpuForest` — creates GPU buffers sized for up to `max_samples` rows. Pre-allocates 4 buffers at init; no per-call VRAM allocation.
-- `GpuForest::fork(&self, max_samples: usize) -> GpuForest` — clones the `Arc<GpuForestShared>` (device, queue, pipelines, static node/meta buffers) and allocates fresh per-instance buffers. Use this to get per-thread handles without recompiling shaders or re-uploading node data.
+- `GpuForest::fork(&self, max_samples: usize) -> GpuForest` — clones the `Arc<GpuForestShared>` (device, queue, pipelines, static node/meta buffers) and allocates fresh per-instance buffers. Use this to get per-thread handles without recompiling shaders or re-uploading node data. Inherits `collect_timeout` from the parent.
+- `GpuForest::is_uma() -> bool` — returns `true` when the adapter supports `MAPPABLE_PRIMARY_BUFFERS` (Apple Silicon, Vulkan/DX12 UMA). Useful for logging/telemetry.
+- `GpuForest::with_collect_timeout(Duration) -> GpuForest` — builder method to set the maximum wait time for `PredictHandle::collect`. Default: 10 seconds. Returns `self` for chaining after `from_flat_forest`.
 - `GpuForest::predict(&ArrayView2<f32>) -> Array1<f32>` — calls `predict_submit` then `collect`. Uses `X.as_standard_layout()` internally to get a contiguous slice (zero-copy if already C-order).
-- `GpuForest::predict_submit(&ArrayView2<f32>) -> Option<PredictHandle<'_>>` — submits GPU work immediately; returns `None` for empty input. `PredictHandle::collect() -> Array1<f32>` blocks until done. Use submit+collect to overlap GPU work across multiple forests.
-- Writes features via `queue.write_buffer`, creates sub-range bind groups so `arrayLength()` in the shader sees `n_samples` (not `max_samples`), submits, waits with `device.poll(PollType::Wait { submission_index: Some(idx), timeout: None })`, reads staging buffer, calls `staging_buffer.unmap()`.
+- `GpuForest::predict_submit(&ArrayView2<f32>) -> Option<PredictHandle<'_>>` — submits GPU work immediately; returns `None` for empty input. `PredictHandle::collect() -> Array1<f32>` blocks until done (up to `collect_timeout`). Use submit+collect to overlap GPU work across multiple forests. **Panics if called while a previous `PredictHandle` is still outstanding** (busy flag via `AtomicBool`).
 - Sub-range binding: pass `wgpu::BufferBinding { buffer, offset: 0, size: Some(BufferSize::new(feature_bytes)) }` — this is essential for `arrayLength()` to reflect the actual batch size, not buffer capacity.
-- wgpu 28 poll API: `queue.submit()` returns a `SubmissionIndex`; pass it to `device.poll(PollType::Wait { submission_index: Some(idx), timeout: None })` for per-submission blocking wait.
+- wgpu 28 poll API: `queue.submit()` returns a `SubmissionIndex`; pass it to `device.poll(PollType::Wait { submission_index: Some(idx), timeout: Some(duration) })` for per-submission blocking wait with timeout.
 - Always call `staging_buffer.unmap()` after reading from a pre-allocated (reused) staging buffer, so the next `encoder.copy_buffer_to_buffer` + map cycle works correctly.
+
+**UMA (Unified Memory Architecture) optimisation:**
+- Detection: `adapter.features().contains(MAPPABLE_PRIMARY_BUFFERS)`, requested in `DeviceDescriptor::required_features`. Stored as `GpuForestShared::uma`; forked handles inherit it.
+- Feature upload on UMA: `STORAGE | MAP_WRITE` buffer, mapped directly via `map_async(Write)` + `poll(Wait { submission_index: None, timeout: Some(1s) })` + `copy_from_slice`. No staging blit. The 1-second timeout catches wgpu validation errors that would otherwise hang.
+- Output readback on UMA: `STORAGE | MAP_READ` buffer mapped directly via `map_async(Read)`; no `copy_buffer_to_buffer` + staging buffer needed.
+- On discrete GPUs: feature upload uses `queue.write_buffer` (STORAGE | COPY_DST); output copied to a `COPY_DST | MAP_READ` staging buffer before readback.
+- `staging_buffer: Option<wgpu::Buffer>` is `None` on UMA, `Some(...)` on discrete.
+
+**Busy flag (double-submit guard):**
+- `GpuForest::busy: AtomicBool` — set to `true` via `swap(true, Acquire)` at the start of `predict_submit`, reset to `false` via `store(false, Release)` at the end of `PredictHandle::collect`. Panics with "outstanding PredictHandle" if `predict_submit` is called while a handle is still live.
 
 **wgpu 28 pipeline overridable constants (workgroup size):**
 - WGSL: `override wg_size: u32 = 64u;` at top of shader, then `@compute @workgroup_size(wg_size, 1, 1)`. Override expressions are valid in `@workgroup_size`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,19 @@ The `MaxFeatures` enum supports multiple feature sampling strategies:
 - `src/gpu/shaders/reduce.wgsl` — averages per-tree predictions per sample.
 - Tests: `tests/flat_forest.rs` (CPU, no feature flag), `tests/gpu_inference.rs` (requires GPU, `--features gpu`).
 
+**GpuForest API (wgpu 28):**
+- `GpuForest::from_flat_forest(flat: &FlatForest, max_samples: usize) -> GpuForest` — creates GPU buffers sized for up to `max_samples` rows. Pre-allocates 4 buffers at init; no per-call VRAM allocation.
+- `GpuForest::fork(&self, max_samples: usize) -> GpuForest` — clones the `Arc<GpuForestShared>` (device, queue, pipelines, static node/meta buffers) and allocates fresh per-instance buffers. Use this to get per-thread handles without recompiling shaders or re-uploading node data.
+- `GpuForest::predict(features: &[f32], n_samples: usize) -> Vec<f32>` — writes features via `queue.write_buffer`, creates sub-range bind groups so `arrayLength()` in the shader sees `n_samples` (not `max_samples`), submits, waits with `device.poll(PollType::Wait { submission_index: Some(idx), timeout: None })`, reads staging buffer, calls `staging_buffer.unmap()`.
+- Sub-range binding: pass `wgpu::BufferBinding { buffer, offset: 0, size: Some(BufferSize::new(feature_bytes)) }` — this is essential for `arrayLength()` to reflect the actual batch size, not buffer capacity.
+- wgpu 28 poll API: `queue.submit()` returns a `SubmissionIndex`; pass it to `device.poll(PollType::Wait { submission_index: Some(idx), timeout: None })` for per-submission blocking wait.
+- Always call `staging_buffer.unmap()` after reading from a pre-allocated (reused) staging buffer, so the next `encoder.copy_buffer_to_buffer` + map cycle works correctly.
+
+**Thread safety and TLS on Metal/wgpu:**
+- wgpu/Metal GPU resources held in `thread_local!` cause `"cannot access a Thread Local Storage value during or after destruction: AccessError"` when rayon worker threads tear down, because Metal's OS autorelease pool is destroyed before Rust TLS destructors run.
+- Fix: explicitly drop GPU resources in rayon's `exit_handler`, which runs while the thread is still alive (before TLS destructors). Example: `.exit_handler(|_| { GPU_FORESTS.with(|gf| { gf.borrow_mut().take(); }); })`
+- This is cleaner than pre-allocating a `Vec<GpuForest>` indexed by thread, because lazy init and cleanup both stay local to the thread.
+
 **Why not BFS positional encoding (`2i+1`/`2i+2`):**
 Real-world RF trees trained without a `max_depth` constraint are deep and sparse. A positional BFS layout requires `2^(depth+1) - 1` slots per tree — depth ~44 means petabytes of allocation. Explicit child indices allocate only actual nodes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,11 +56,14 @@ The `MaxFeatures` enum supports multiple feature sampling strategies:
 ## GPU Feature (`--features gpu`)
 
 **What was built:**
-- `src/flat_forest.rs` — `FlatForest` / `FlatNode`: BFS-encoded flat tree array usable for both CPU and GPU inference. `FlatForest::from_forest(forest, n_features)` flattens all trees (padded to uniform `max_tree_size = 2^(max_depth+1) - 1`). `FlatForest::predict` matches `RandomForest::predict` exactly.
+- `src/flat_forest.rs` — `FlatForest` / `FlatNode`: flat tree array usable for both CPU and GPU inference. Nodes are stored in BFS visit order with **explicit child indices** (`left: i32`, `right: i32`; -1 for leaves). `max_tree_size` is the actual maximum node count across trees (NOT `2^(max_depth+1) - 1`). `FlatForest::from_forest(forest, n_features)` flattens all trees; `FlatForest::predict` matches `RandomForest::predict` exactly.
 - `src/gpu/pipeline.rs` — `GpuForest`: uploads `FlatForest` to GPU (f64→f32), compiles WGSL pipelines, runs batched inference via `predict(&[f32], n_samples) -> Vec<f32>`.
-- `src/gpu/shaders/traverse.wgsl` — 2D dispatch `(ceil(n_samples/64), n_trees, 1)`, one thread per (sample, tree).
+- `src/gpu/shaders/traverse.wgsl` — 2D dispatch `(ceil(n_samples/64), n_trees, 1)`, one thread per (sample, tree). Uses `u32(node.left)` / `u32(node.right)` for traversal; `max_depth` is kept as a GPU loop safety bound only.
 - `src/gpu/shaders/reduce.wgsl` — averages per-tree predictions per sample.
 - Tests: `tests/flat_forest.rs` (CPU, no feature flag), `tests/gpu_inference.rs` (requires GPU, `--features gpu`).
+
+**Why not BFS positional encoding (`2i+1`/`2i+2`):**
+Real-world RF trees trained without a `max_depth` constraint are deep and sparse. A positional BFS layout requires `2^(depth+1) - 1` slots per tree — depth ~44 means petabytes of allocation. Explicit child indices allocate only actual nodes.
 
 ## Known pre-existing issue
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,11 +58,22 @@ The `MaxFeatures` enum supports multiple feature sampling strategies:
 ## GPU Feature (`--features gpu`)
 
 **What was built:**
-- `src/flat_forest.rs` — `FlatForest` / `FlatNode`: flat tree array usable for both CPU and GPU inference. Nodes are stored in BFS visit order with **explicit child indices** (`left: i32`, `right: i32`; -1 for leaves). `max_tree_size` is the actual maximum node count across trees (NOT `2^(max_depth+1) - 1`). `FlatForest::from_forest(forest, n_features)` flattens all trees; `FlatForest::predict` matches `RandomForest::predict` exactly.
-- `src/gpu/pipeline.rs` — `GpuForest`: uploads `FlatForest` to GPU (f64→f32), compiles WGSL pipelines, runs batched inference via `predict(&[f32], n_samples) -> Vec<f32>`.
-- `src/gpu/shaders/traverse.wgsl` — 2D dispatch `(ceil(n_samples/64), n_trees, 1)`, one thread per (sample, tree). Uses `u32(node.left)` / `u32(node.right)` for traversal; `max_depth` is kept as a GPU loop safety bound only.
+- `src/flat_forest.rs` — `FlatForest` / `FlatNode` / `ForestMeta`: flat tree array for CPU and GPU inference. Nodes in BFS visit order with **explicit child indices** (`left: i32`, `right: i32`; -1 for leaves). `max_tree_size` is the actual max node count across trees (NOT `2^(max_depth+1) - 1`). `FlatForest.meta: ForestMeta` holds the four `u32` dimensions; `FlatForest` impls `Deref<Target = ForestMeta>` for ergonomic access.
+- `src/gpu/pipeline.rs` — `GpuForest`: uploads `FlatForest` nodes **directly** (already `f32`; zero conversion), compiles WGSL pipelines with device-queried workgroup size, runs batched inference via `predict(&[f32], n_samples) -> Vec<f32>`.
+- `src/gpu/shaders/traverse.wgsl` — 2D dispatch `(ceil(n_samples/wg_size), n_trees, 1)`, one thread per (sample, tree). Uses `u32(node.left)` / `u32(node.right)` for traversal; `max_depth` is the GPU loop safety bound.
 - `src/gpu/shaders/reduce.wgsl` — averages per-tree predictions per sample.
 - Tests: `tests/flat_forest.rs` (CPU, no feature flag), `tests/gpu_inference.rs` (requires GPU, `--features gpu`).
+
+**FlatNode layout (16 bytes, `#[repr(C)]`):**
+```
+left: i32 | right: i32 | feature_index: u32 | value: f32
+```
+`value` is dual-purpose: split threshold for internal nodes, leaf prediction for leaves. `left < 0` is the sole discriminant — no separate `is_leaf` field needed. 16 bytes = exactly 4 nodes per 64-byte cache line. Under `gpu` feature, `FlatNode` and `ForestMeta` derive `bytemuck::Pod + Zeroable`, so nodes upload as `bytemuck::cast_slice::<FlatNode, u8>(&flat.nodes)` with no conversion loop.
+
+**Precision model:**
+- `FlatNode` stores `value: f32`. `FlatForest::predict` casts each feature to `f32` before comparison so that CPU and GPU traversal are identical.
+- `FlatForest::predict` results differ from `RandomForest::predict` (f64) by ~1e-5 due to f32 quantisation of leaf values; use that tolerance in tests.
+- `FlatForest::predict` vs `GpuForest::predict` differ by <1e-5 (only f64 vs f32 accumulation of f32 leaf values).
 
 **GpuForest API (wgpu 28):**
 - `GpuForest::from_flat_forest(flat: &FlatForest, max_samples: usize) -> GpuForest` — creates GPU buffers sized for up to `max_samples` rows. Pre-allocates 4 buffers at init; no per-call VRAM allocation.
@@ -71,6 +82,11 @@ The `MaxFeatures` enum supports multiple feature sampling strategies:
 - Sub-range binding: pass `wgpu::BufferBinding { buffer, offset: 0, size: Some(BufferSize::new(feature_bytes)) }` — this is essential for `arrayLength()` to reflect the actual batch size, not buffer capacity.
 - wgpu 28 poll API: `queue.submit()` returns a `SubmissionIndex`; pass it to `device.poll(PollType::Wait { submission_index: Some(idx), timeout: None })` for per-submission blocking wait.
 - Always call `staging_buffer.unmap()` after reading from a pre-allocated (reused) staging buffer, so the next `encoder.copy_buffer_to_buffer` + map cycle works correctly.
+
+**wgpu 28 pipeline overridable constants (workgroup size):**
+- WGSL: `override wg_size: u32 = 64u;` at top of shader, then `@compute @workgroup_size(wg_size, 1, 1)`. Override expressions are valid in `@workgroup_size`.
+- Rust: `PipelineCompilationOptions { constants: &[("wg_size", value_as_f64)], ..Default::default() }`. The type is `&[(&str, f64)]` — **not** `HashMap<String, f64>` (that was an older wgpu API).
+- Workgroup size heuristic: `device.limits().max_compute_invocations_per_workgroup.min(device.limits().max_compute_workgroup_size_x).min(256)`. Clamp both per-group and per-X-dimension limits; cap at 256 (larger groups rarely help memory-bandwidth-bound kernels). Store result in `GpuForestShared::workgroup_size` and use in `n_samples.div_ceil(shared.workgroup_size)` dispatch.
 
 **Thread safety and TLS on Metal/wgpu:**
 - wgpu/Metal GPU resources held in `thread_local!` cause `"cannot access a Thread Local Storage value during or after destruction: AccessError"` when rayon worker threads tear down, because Metal's OS autorelease pool is destroyed before Rust TLS destructors run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,10 @@ The repository consists of:
 
 ## Development Commands
 
+Run tests with all features:
+
 ```bash
-cargo test --features serde
+cargo test --all-features
 ```
 
 *Note:** Add/update tests when APIs are added or changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# Information for Coding Agents
+
+Biosphere is a Rust library for fast and simple Random Forests.
+
+## Project Overview
+
+The repository consists of:
+- **Rust core library** (`src/`): Core random forest and decision tree implementation
+- **Python bindings** (`biosphere-py/`): PyO3-based Python package built with Maturin
+
+## Development Commands
+
+```bash
+cargo test --features serde
+```
+
+*Note:** Add/update tests when APIs are added or changed.
+
+## Core Components
+
+1. **DecisionTree** (`src/tree/decision_tree.rs`)
+   - Individual decision tree implementation
+   - Uses sorted samples for efficient splitting
+   - Configured via `DecisionTreeParameters`
+
+2. **RandomForest** (`src/forest.rs`)
+   - Ensemble of decision trees
+   - Parallel training using rayon threadpool
+   - OOB (out-of-bag) prediction support
+   - Configured via `RandomForestParameters`
+
+3. **Tree Node Structure** (`src/tree/decision_tree_node.rs`)
+   - Recursive tree node implementation
+   - Handles splitting logic and prediction
+
+4. **Utilities** (`src/utils.rs`)
+   - `argsort`: Sorting indices computation
+   - `sample_weights`: Bootstrap sample generation
+   - `sorted_samples`: Pre-sorting optimization for training
+
+## Important Implementation Notes
+
+**Array Naming Convention:**
+The codebase uses capital `X` for feature arrays (following scikit-learn convention) and allows this via `#![allow(non_snake_case)]` in lib.rs.
+
+**Random State:**
+- Seeds are u64 values
+- Each tree in a forest gets a derived seed for reproducibility
+- Uses `StdRng` from rand crate
+
+**MaxFeatures Options:**
+The `MaxFeatures` enum supports multiple feature sampling strategies:
+- `None`: Use all features
+- `Value(usize)`: Use specific number of features
+- `Fraction(f64)`: Use fraction of features
+- `Sqrt`: Use sqrt(n_features)
+
+# Agent Instructions
+
+**Keep this file updated.** After every session where you discover something stable and non-obvious about this project, add it below. Remove or correct entries that turn out to be wrong or outdated. Do not duplicate entries already in CLAUDE.md.
+
+## Interactivity guidelines
+
+When you are asked to implement something, always ask for clarifications if needed.
+If you are unsure about the requirements, ask for more details.
+If you think there is a better way to implement something, suggest it and explain your reasoning, but don't implement it immediately without approval.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ name = "biosphere"
 ndarray = "0.17.1"
 rand = "0.9"
 rayon = "1.11"
+serde = { version = "1", features = ["derive"], optional = true }
+
+[features]
+serde = ["dep:serde"]
 
 [profile.bench]
 incremental = true
@@ -30,6 +34,7 @@ csv = "^1"
 ndarray-csv = "^0.5"
 criterion = "0.8"
 assert_approx_eq = "1.1"
+postcard = { version = "1", features = ["use-std"] }
 
 [[bench]]
 name = "bench_utils"
@@ -42,3 +47,8 @@ harness = false
 [[bench]]
 name = "bench_tree"
 harness = false
+
+[[bench]]
+name = "bench_tree_serde"
+harness = false
+required-features = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/mlondschien/biosphere/"
 readme = "README.md"
 license = "BSD-3-Clause"
 version = "0.4.2"
-edition = "2021"
+edition = "2024"
 exclude = ["/.github", "/changeforest-py", ".pre-commit-config.yaml", ".gitignore"]
 keywords = ["machine-learning", "random-forest", "decision-tree", "ensemble", "tree"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bytemuck = { version = "1", optional = true, features = ["derive"] }
 pollster = { version = "0.4", optional = true }
 
 [features]
-serde = ["dep:serde"]
+serde = ["dep:serde", "dep:bytemuck"]
 gpu = ["dep:wgpu", "dep:bytemuck", "dep:pollster"]
 
 [profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "biosphere"
 description = "Simple, fast random forests."
-authors = ["Malte Londschien <malte@londschien.ch>"]
+authors = [
+    "Malte Londschien <malte@londschien.ch>",
+    "Pascal Hertleif <pascal@softleif.se>"
+]
 repository = "https://github.com/mlondschien/biosphere/"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 exclude = ["/.github", "/changeforest-py", ".pre-commit-config.yaml", ".gitignore"]
 keywords = ["machine-learning", "random-forest", "decision-tree", "ensemble", "tree"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,13 @@ ndarray = "0.17.2"
 rand = "0.9.2"
 rayon = "1.11"
 serde = { version = "1.0.228", optional = true, features = [ "derive" ] }
+wgpu = { version = "28", optional = true }
+bytemuck = { version = "1", optional = true, features = ["derive"] }
+pollster = { version = "0.4", optional = true }
 
 [features]
 serde = ["dep:serde"]
+gpu = ["dep:wgpu", "dep:bytemuck", "dep:pollster"]
 
 [profile.bench]
 incremental = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ keywords = ["machine-learning", "random-forest", "decision-tree", "ensemble", "t
 name = "biosphere"
 
 [dependencies]
-ndarray = "0.17.1"
-rand = "0.9"
+ndarray = "0.17.2"
+rand = "0.9.2"
 rayon = "1.11"
-serde = { version = "1", features = ["derive"], optional = true }
+serde = { version = "1.0.228", optional = true, features = [ "derive" ] }
 
 [features]
 serde = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,10 @@ harness = false
 name = "bench_tree"
 harness = false
 
+[[test]]
+name = "flat_forest_serde"
+required-features = ["serde"]
+
 [[bench]]
 name = "bench_tree_serde"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,8 @@ harness = false
 name = "bench_tree_serde"
 harness = false
 required-features = ["serde"]
+
+[[bench]]
+name = "bench_gpu"
+harness = false
+required-features = ["gpu"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,35 @@ Random forests with a runtime of `O(n d log(n) + n_estimators d n max_depth)` in
 
 `biosphere` is available as a rust crate and as a Python package.
 
+## Serialize / deserialize a `DecisionTree`
+
+Enable the `serde` feature and choose a serde format (here: `postcard`):
+
+```toml
+# Cargo.toml
+biosphere = { version = "0.4.2", features = ["serde"] }
+postcard = { version = "1", features = ["use-std"] }
+```
+
+```rust
+use biosphere::DecisionTree;
+
+let X = ndarray::array![[0.0], [1.0], [2.0], [3.0]];
+let y = ndarray::array![0.0, 0.0, 1.0, 1.0];
+
+let mut tree = DecisionTree::default();
+tree.fit(&X.view(), &y.view());
+
+// serialize and deserialize the tree
+let bytes = postcard::to_stdvec(&tree).unwrap();
+// deserialize the tree from bytes
+let restored: DecisionTree = postcard::from_bytes(&bytes).unwrap();
+
+assert_eq!(tree.predict(&X.view()), restored.predict(&X.view()));
+```
+
+In this repo you can run: `cargo run --example decision_tree_serde --features serde`.
+
 ## Benchmarks
 
 Ran on an M1 Pro with `n_jobs=4`. Wall-time to fit a Random Forest including OOB score with 400 trees to

--- a/README.md
+++ b/README.md
@@ -6,6 +6,43 @@ Random forests with a runtime of `O(n d log(n) + n_estimators d n max_depth)` in
 
 `biosphere` is available as a rust crate and as a Python package.
 
+## GPU Inference
+
+Enable the `gpu` feature for wgpu-based GPU inference:
+
+```toml
+biosphere = { version = "0.5", features = ["gpu"] }
+```
+
+Convert a trained `RandomForest` to a flat representation and run inference on the GPU:
+
+```rust
+use biosphere::{RandomForest, FlatForest};
+use biosphere::gpu::GpuForest;
+
+// train as usual
+let mut forest = RandomForest::default();
+forest.fit(&X.view(), &y.view());
+
+// convert and upload to GPU
+let flat = FlatForest::from(&forest);
+let gpu = GpuForest::from_flat_forest(&flat, /* max_samples */ 1024);
+
+// predict — returns Vec<f32>, one value per sample
+let predictions = gpu.predict(&features_flat, n_samples);
+```
+
+For multithreaded use, call `gpu.fork()` to get a per-thread handle that shares compiled shaders and node data without re-uploading anything.
+
+For overlapping CPU and GPU work, use `predict_submit` / `PredictHandle::collect` separately.
+
+`FlatForest` also works on CPU without the `gpu` feature — the cache-friendly f32 node layout gives a modest speedup over `RandomForest::predict`, at the cost of f32 precision (~1e-5 difference in leaf values):
+
+```rust
+let flat = FlatForest::from(&forest);
+let predictions = flat.predict(&X.view()); // Vec<f32>
+```
+
 ## Serialize / deserialize a `DecisionTree`
 
 Enable the `serde` feature and choose a serde format (here: `postcard`):
@@ -34,15 +71,3 @@ assert_eq!(tree.predict(&X.view()), restored.predict(&X.view()));
 ```
 
 In this repo you can run: `cargo run --example decision_tree_serde --features serde`.
-
-## Benchmarks
-
-Ran on an M1 Pro with `n_jobs=4`. Wall-time to fit a Random Forest including OOB score with 400 trees to
-the [NYC Taxi dataset](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page),
-minimum over 10 runs. After feature engineering, the dataset consists of 5 numerical and 7 one-hot encoded
-features.
-
-| model        | 1000   | 2000   | 4000   | 8000   | 16000   | 32000   | 64000   | 128000   | 256000   | 512000   | 1024000   | 2048000   |
-|:-------------|:-------|:-------|:-------|:-------|:--------|:--------|:--------|:---------|:---------|:---------|:----------|:----------|
-| biosphere    | 0.04s  | 0.08s  | 0.15s  | 0.32s  | 0.65s   | 1.40s   | 2.97s   | 6.48s    | 15.53s   | 37.91s   | 96.69s    | 231.82s   |
-| scikit-learn | 0.28s  | 0.34s  | 0.46s  | 0.69s  | 1.23s   | 2.47s   | 4.99s   | 10.49s   | 22.11s   | 51.04s   | 118.95s   | 271.03s   |

--- a/benches/bench_forest.rs
+++ b/benches/bench_forest.rs
@@ -1,13 +1,13 @@
 use biosphere::{RandomForest, RandomForestParameters};
 
 #[cfg(test)]
-use criterion::{criterion_group, criterion_main, Criterion};
-use ndarray::{s, Array, Array1, Array2};
-use ndarray_rand::rand_distr::{Bernoulli, Uniform};
+use criterion::{Criterion, criterion_group, criterion_main};
+use ndarray::{Array, Array1, Array2, s};
 use ndarray_rand::RandomExt;
-use rand::rngs::StdRng;
+use ndarray_rand::rand_distr::{Bernoulli, Uniform};
 use rand::Rng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 
 #[allow(non_snake_case)]
 pub fn data(n: usize, d: usize, rng: &mut impl Rng) -> (Array2<f64>, Array1<f64>) {
@@ -22,13 +22,8 @@ pub fn data(n: usize, d: usize, rng: &mut impl Rng) -> (Array2<f64>, Array1<f64>
             ));
         } else {
             X.slice_mut(s![.., i]).assign(
-                &Array::random_using((n,), Bernoulli::new(0.3).unwrap(), rng).mapv(|x| {
-                    if x {
-                        1.0
-                    } else {
-                        0.0
-                    }
-                }),
+                &Array::random_using((n,), Bernoulli::new(0.3).unwrap(), rng)
+                    .mapv(|x| if x { 1.0 } else { 0.0 }),
             );
         }
     }

--- a/benches/bench_gpu.rs
+++ b/benches/bench_gpu.rs
@@ -1,0 +1,83 @@
+/// Benchmarks comparing CPU and GPU inference for the same trained forest.
+///
+/// Run with:
+///   cargo bench --features gpu --bench bench_gpu
+///
+/// The benchmark group "predict" varies batch size across three backends:
+///   - `RandomForest`  — original tree-of-structs CPU inference
+///   - `FlatForest`    — flat BFS array CPU inference
+///   - `GpuForest`     — GPU inference via wgpu compute shaders
+///
+/// Throughput is reported in samples/s so the numbers are directly comparable
+/// across batch sizes.
+use biosphere::gpu::GpuForest;
+use biosphere::{FlatForest, RandomForest, RandomForestParameters};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use ndarray::Array2;
+use ndarray_rand::RandomExt;
+use ndarray_rand::rand_distr::Uniform;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+const N_TRAIN: usize = 1_000;
+const N_FEATURES: usize = 20;
+/// Batch sizes to sweep. Larger sizes favour the GPU; smaller sizes favour CPU.
+const SAMPLE_SIZES: &[usize] = &[100, 1_000, 10_000, 100_000];
+
+#[allow(non_snake_case)]
+fn make_X(n: usize, seed: u64) -> Array2<f64> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    Array2::random_using((n, N_FEATURES), Uniform::new(0.0, 1.0).unwrap(), &mut rng)
+}
+
+#[allow(non_snake_case)]
+fn benchmark_predict(c: &mut Criterion) {
+    // --- Train once, outside the timed loop ---
+    let X_train = make_X(N_TRAIN, 0);
+    let y_train = X_train.column(0).to_owned();
+
+    let params = RandomForestParameters::default()
+        .with_n_estimators(100)
+        .with_max_depth(Some(8))
+        .with_seed(42);
+
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X_train.view(), &y_train.view());
+
+    let flat = FlatForest::from_forest(&forest, N_FEATURES);
+
+    let max_n = *SAMPLE_SIZES.iter().max().unwrap();
+    let gpu = GpuForest::from_flat_forest(&flat, max_n);
+
+    let mut group = c.benchmark_group("predict");
+
+    for &n in SAMPLE_SIZES {
+        let X_infer = make_X(n, 1);
+        // Pre-convert to f32 once; the conversion itself is not under measurement.
+        let X_f32: Vec<f32> = X_infer.iter().map(|&v| v as f32).collect();
+
+        group.throughput(Throughput::Elements(n as u64));
+
+        group.bench_with_input(BenchmarkId::new("RandomForest", n), &n, |b, _| {
+            b.iter(|| forest.predict(&X_infer.view()))
+        });
+
+        group.bench_with_input(BenchmarkId::new("FlatForest", n), &n, |b, _| {
+            b.iter(|| flat.predict(&X_infer.view()))
+        });
+
+        group.bench_with_input(BenchmarkId::new("GpuForest", n), &n, |b, _| {
+            b.iter(|| gpu.predict(&X_f32, n))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    name = gpu_bench;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_predict
+);
+
+criterion_main!(gpu_bench);

--- a/benches/bench_gpu.rs
+++ b/benches/bench_gpu.rs
@@ -47,7 +47,7 @@ fn benchmark_predict(c: &mut Criterion) {
     let flat = FlatForest::from_forest(&forest, N_FEATURES);
 
     let max_n = *SAMPLE_SIZES.iter().max().unwrap();
-    let gpu = GpuForest::from_flat_forest(&flat, max_n);
+    let gpu = GpuForest::from_flat_forest(&flat, max_n).unwrap();
 
     let mut group = c.benchmark_group("predict");
 

--- a/benches/bench_gpu.rs
+++ b/benches/bench_gpu.rs
@@ -54,7 +54,7 @@ fn benchmark_predict(c: &mut Criterion) {
     for &n in SAMPLE_SIZES {
         let X_infer = make_X(n, 1);
         // Pre-convert to f32 once; the conversion itself is not under measurement.
-        let X_f32: Vec<f32> = X_infer.iter().map(|&v| v as f32).collect();
+        let X_f32 = X_infer.mapv(|v| v as f32);
 
         group.throughput(Throughput::Elements(n as u64));
 
@@ -67,7 +67,7 @@ fn benchmark_predict(c: &mut Criterion) {
         });
 
         group.bench_with_input(BenchmarkId::new("GpuForest", n), &n, |b, _| {
-            b.iter(|| gpu.predict(&X_f32, n))
+            b.iter(|| gpu.predict(&X_f32.view()))
         });
     }
 

--- a/benches/bench_gpu.rs
+++ b/benches/bench_gpu.rs
@@ -63,7 +63,7 @@ fn benchmark_predict(c: &mut Criterion) {
         });
 
         group.bench_with_input(BenchmarkId::new("FlatForest", n), &n, |b, _| {
-            b.iter(|| flat.predict(&X_infer.view()))
+            b.iter(|| flat.predict(&X_f32.view()))
         });
 
         group.bench_with_input(BenchmarkId::new("GpuForest", n), &n, |b, _| {

--- a/benches/bench_tree.rs
+++ b/benches/bench_tree.rs
@@ -2,13 +2,13 @@ use biosphere::utils::{argsort, sample_indices_from_weights, sample_weights};
 use biosphere::{DecisionTree, DecisionTreeParameters, MaxFeatures};
 
 #[cfg(test)]
-use criterion::{criterion_group, criterion_main, Criterion};
-use ndarray::{s, Array, Array1, Array2};
-use ndarray_rand::rand_distr::{Bernoulli, Uniform};
+use criterion::{Criterion, criterion_group, criterion_main};
+use ndarray::{Array, Array1, Array2, s};
 use ndarray_rand::RandomExt;
-use rand::rngs::StdRng;
+use ndarray_rand::rand_distr::{Bernoulli, Uniform};
 use rand::Rng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 
 #[allow(non_snake_case)]
 pub fn data(n: usize, d: usize, rng: &mut impl Rng) -> (Array2<f64>, Array1<f64>) {

--- a/benches/bench_tree_serde.rs
+++ b/benches/bench_tree_serde.rs
@@ -1,0 +1,72 @@
+use biosphere::{DecisionTree, DecisionTreeParameters, MaxFeatures};
+
+#[cfg(test)]
+use criterion::{criterion_group, criterion_main, Criterion};
+use ndarray::{Array1, Array2};
+use rand::rngs::StdRng;
+use rand::Rng;
+use rand::SeedableRng;
+use std::hint::black_box;
+
+#[allow(non_snake_case)]
+pub fn data(n: usize, d: usize, rng: &mut impl Rng) -> (Array2<f64>, Array1<f64>) {
+    let X = Array2::from_shape_fn((n, d), |_| rng.random::<f64>());
+
+    let y = Array1::from_shape_fn(n, |_| rng.random::<f64>());
+    let y = y + X.column(0) + X.column(1).map(|x| x - x * x);
+
+    (X, y)
+}
+
+#[allow(non_snake_case)]
+pub fn benchmark_tree_fit_vs_deserialize(c: &mut Criterion) {
+    let seed = 0;
+    let mut rng = StdRng::seed_from_u64(seed);
+
+    let n = 10_000usize;
+    let d = 10usize;
+    let max_depth = 8usize;
+
+    let (X, y) = data(n, d, &mut rng);
+    let X_view = X.view();
+    let y_view = y.view();
+
+    let parameters = DecisionTreeParameters::default()
+        .with_max_depth(Some(max_depth))
+        .with_max_features(MaxFeatures::Value(d))
+        .with_random_state(seed);
+
+    let mut fitted_tree = DecisionTree::new(parameters.clone());
+    fitted_tree.fit(&X_view, &y_view);
+    let fitted_tree_bytes = postcard::to_stdvec(&fitted_tree).unwrap();
+
+    let mut group = c.benchmark_group("tree_fit_vs_deserialize");
+    group.bench_function(format!("fit_n={n}, d={d}, max_depth={max_depth}"), |b| {
+        b.iter(|| {
+            let mut tree = DecisionTree::new(parameters.clone());
+            tree.fit(&X_view, &y_view);
+            black_box(tree);
+        })
+    });
+
+    group.bench_function(
+        format!("deserialize_n={n}, d={d}, max_depth={max_depth}"),
+        |b| {
+            b.iter(|| {
+                let tree: DecisionTree =
+                    postcard::from_bytes(black_box(fitted_tree_bytes.as_slice())).unwrap();
+                black_box(tree);
+            })
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(
+    name = tree_serde;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_tree_fit_vs_deserialize
+);
+
+criterion_main!(tree_serde);

--- a/benches/bench_tree_serde.rs
+++ b/benches/bench_tree_serde.rs
@@ -1,11 +1,11 @@
 use biosphere::{DecisionTree, DecisionTreeParameters, MaxFeatures};
 
 #[cfg(test)]
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use ndarray::{Array1, Array2};
-use rand::rngs::StdRng;
 use rand::Rng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 use std::hint::black_box;
 
 #[allow(non_snake_case)]

--- a/benches/bench_utils.rs
+++ b/benches/bench_utils.rs
@@ -2,12 +2,12 @@ use biosphere::utils::{
     argsort, oob_samples_from_weights, sample_indices_from_weights, sample_weights,
 };
 #[cfg(test)]
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use ndarray::Array;
-use ndarray_rand::rand_distr::{Bernoulli, Uniform};
 use ndarray_rand::RandomExt;
-use rand::rngs::StdRng;
+use ndarray_rand::rand_distr::{Bernoulli, Uniform};
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 
 pub fn benchmark_utils(c: &mut Criterion) {
     let seed = 0;
@@ -19,13 +19,8 @@ pub fn benchmark_utils(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("argsort_continuous", size), &x, |b, x| {
             b.iter(|| argsort(x))
         });
-        let y = Array::random_using(size, Bernoulli::new(0.3).unwrap(), &mut rng).mapv(|x| {
-            if x {
-                1.0
-            } else {
-                0.0
-            }
-        });
+        let y = Array::random_using(size, Bernoulli::new(0.3).unwrap(), &mut rng)
+            .mapv(|x| if x { 1.0 } else { 0.0 });
         group.bench_with_input(BenchmarkId::new("argsort_one_hot", size), &y, |b, x| {
             b.iter(|| argsort(x))
         });

--- a/examples/decision_tree_serde.rs
+++ b/examples/decision_tree_serde.rs
@@ -1,0 +1,26 @@
+#![allow(non_snake_case)]
+
+#[cfg(not(feature = "serde"))]
+fn main() {
+    eprintln!(
+        "This example requires the `serde` feature.\n\nRun:\n  cargo run --example decision_tree_serde --features serde"
+    );
+}
+
+#[cfg(feature = "serde")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use biosphere::DecisionTree;
+
+    let X = ndarray::array![[0.0], [1.0], [2.0], [3.0]];
+    let y = ndarray::array![0.0, 0.0, 1.0, 1.0];
+
+    let mut tree = DecisionTree::default();
+    tree.fit(&X.view(), &y.view());
+
+    let bytes = postcard::to_stdvec(&tree)?;
+    let restored: DecisionTree = postcard::from_bytes(&bytes)?;
+
+    assert_eq!(tree.predict(&X.view()), restored.predict(&X.view()));
+    println!("Serialized {} bytes", bytes.len());
+    Ok(())
+}

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -100,12 +100,12 @@ impl FlatNode {
 /// [`GpuForest::from_flat_forest`]: crate::gpu::GpuForest::from_flat_forest
 /// [`RandomForest`]: crate::RandomForest
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FlatForest {
     /// Flat node array: length = `meta.n_trees * meta.max_tree_size`.
-    // Serialized as raw bytes via bytemuck for speed (no per-field encoding).
-    #[cfg_attr(feature = "serde", serde(with = "flat_node_serde"))]
     pub(crate) nodes: Vec<FlatNode>,
+    /// Number of real (non-padding) nodes in each tree; computed once in
+    /// `from_forest` alongside `max_tree_size` and reused by serde.
+    pub(crate) tree_sizes: Vec<u32>,
     pub meta: ForestMeta,
 }
 
@@ -134,12 +134,9 @@ impl FlatForest {
             .max()
             .unwrap_or(0);
 
-        // Allocate only as many slots as the largest tree actually needs.
-        let max_tree_size = trees
-            .iter()
-            .map(|t| count_nodes(t.root()))
-            .max()
-            .unwrap_or(1);
+        let tree_sizes: Vec<u32> = trees.iter().map(|t| count_nodes(t.root()) as u32).collect();
+
+        let max_tree_size = tree_sizes.iter().copied().max().unwrap_or(1) as usize;
 
         let mut nodes = vec![FlatNode::dummy_leaf(); n_trees * max_tree_size];
 
@@ -150,6 +147,7 @@ impl FlatForest {
 
         FlatForest {
             nodes,
+            tree_sizes,
             meta: ForestMeta {
                 n_trees: n_trees as u32,
                 n_features: n_features as u32,
@@ -215,50 +213,126 @@ impl FlatForest {
 }
 
 #[cfg(feature = "serde")]
-mod flat_node_serde {
-    use super::FlatNode;
+mod serde_impl {
+    use super::{FlatForest, FlatNode, ForestMeta};
     use serde::de::{Error, Visitor};
-    use serde::{Deserializer, Serializer};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use std::fmt;
 
-    pub fn serialize<S: Serializer>(nodes: &Vec<FlatNode>, s: S) -> Result<S::Ok, S::Error> {
-        s.serialize_bytes(bytemuck::cast_slice(nodes.as_slice()))
-    }
+    /// Newtype that serializes/deserializes `Vec<FlatNode>` as raw bytes.
+    struct CompactNodes(Vec<FlatNode>);
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<FlatNode>, D::Error> {
-        d.deserialize_bytes(NodesVisitor)
-    }
-
-    struct NodesVisitor;
-
-    impl<'de> Visitor<'de> for NodesVisitor {
-        type Value = Vec<FlatNode>;
-
-        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "raw bytes encoding a sequence of FlatNodes")
-        }
-
-        fn visit_bytes<E: Error>(self, v: &[u8]) -> Result<Self::Value, E> {
-            nodes_from_bytes(v).map_err(E::custom)
-        }
-
-        fn visit_byte_buf<E: Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
-            self.visit_bytes(&v)
+    impl Serialize for CompactNodes {
+        fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+            s.serialize_bytes(bytemuck::cast_slice(&self.0))
         }
     }
 
-    fn nodes_from_bytes(bytes: &[u8]) -> Result<Vec<FlatNode>, String> {
-        let node_size = std::mem::size_of::<FlatNode>();
-        if bytes.len() % node_size != 0 {
-            return Err(format!(
-                "expected a multiple of {node_size} bytes (FlatNode size), got {}",
-                bytes.len()
-            ));
+    impl<'de> Deserialize<'de> for CompactNodes {
+        fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+            struct V;
+            impl<'de> Visitor<'de> for V {
+                type Value = CompactNodes;
+                fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    write!(f, "raw bytes encoding a sequence of FlatNodes")
+                }
+                fn visit_bytes<E: Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                    let node_size = std::mem::size_of::<FlatNode>();
+                    if v.len() % node_size != 0 {
+                        return Err(E::custom(format!(
+                            "expected a multiple of {node_size} bytes (FlatNode size), got {}",
+                            v.len()
+                        )));
+                    }
+                    let n = v.len() / node_size;
+                    let mut nodes = vec![bytemuck::Zeroable::zeroed(); n];
+                    bytemuck::cast_slice_mut::<FlatNode, u8>(&mut nodes).copy_from_slice(v);
+                    Ok(CompactNodes(nodes))
+                }
+                fn visit_byte_buf<E: Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
+                    self.visit_bytes(&v)
+                }
+            }
+            d.deserialize_bytes(V)
         }
-        let n = bytes.len() / node_size;
-        let mut nodes = vec![bytemuck::Zeroable::zeroed(); n];
-        bytemuck::cast_slice_mut::<FlatNode, u8>(&mut nodes).copy_from_slice(bytes);
-        Ok(nodes)
+    }
+
+    /// Wire format: metadata + per-tree actual sizes + compact node bytes.
+    /// Padding (dummy leaves) is not stored; it is reconstructed on deserialize.
+    #[derive(Serialize, Deserialize)]
+    struct Wire {
+        meta: ForestMeta,
+        /// Number of real nodes in each tree (prefix of the padded slot array).
+        tree_sizes: Vec<u32>,
+        /// Compact node data: only actual nodes, no padding, raw bytes.
+        nodes: CompactNodes,
+    }
+
+    impl Serialize for FlatForest {
+        fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+            let max_tree_size = self.meta.max_tree_size as usize;
+
+            let total: usize = self.tree_sizes.iter().map(|&s| s as usize).sum();
+            let mut compact = Vec::with_capacity(total);
+            for (i, &size) in self.tree_sizes.iter().enumerate() {
+                let offset = i * max_tree_size;
+                compact.extend_from_slice(&self.nodes[offset..offset + size as usize]);
+            }
+
+            Wire {
+                meta: self.meta,
+                tree_sizes: self.tree_sizes.clone(),
+                nodes: CompactNodes(compact),
+            }
+            .serialize(s)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for FlatForest {
+        fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+            let Wire {
+                meta,
+                tree_sizes,
+                nodes: CompactNodes(compact),
+            } = Wire::deserialize(d)?;
+
+            let n_trees = meta.n_trees as usize;
+            let max_tree_size = meta.max_tree_size as usize;
+
+            if tree_sizes.len() != n_trees {
+                return Err(D::Error::custom(format!(
+                    "expected {n_trees} tree_sizes entries, got {}",
+                    tree_sizes.len()
+                )));
+            }
+            let expected_total: usize = tree_sizes.iter().map(|&s| s as usize).sum();
+            if compact.len() != expected_total {
+                return Err(D::Error::custom(format!(
+                    "expected {expected_total} compact nodes, got {}",
+                    compact.len()
+                )));
+            }
+
+            let mut nodes = vec![FlatNode::dummy_leaf(); n_trees * max_tree_size];
+            let mut src = 0;
+            for (i, &size) in tree_sizes.iter().enumerate() {
+                let size = size as usize;
+                if size > max_tree_size {
+                    return Err(D::Error::custom(format!(
+                        "tree {i}: size {size} exceeds max_tree_size {max_tree_size}"
+                    )));
+                }
+                let dst = i * max_tree_size;
+                nodes[dst..dst + size].copy_from_slice(&compact[src..src + size]);
+                src += size;
+            }
+
+            Ok(FlatForest {
+                nodes,
+                tree_sizes,
+                meta,
+            })
+        }
     }
 }
 
@@ -272,6 +346,7 @@ mod tests {
     use ndarray_rand::rand_distr::Uniform;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
+    use std::mem::size_of;
 
     fn make_data(
         n_samples: usize,
@@ -401,6 +476,53 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Serializing then deserializing a FlatForest produces the same predictions.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_round_trip_predictions() {
+        let (X, y) = make_data(150, 6, 99);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(10)
+            .with_seed(99);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&X.view(), &y.view());
+        let flat = FlatForest::from_forest(&forest, 6);
+
+        let bytes = postcard::to_stdvec(&flat).unwrap();
+        let restored: FlatForest = postcard::from_bytes(&bytes).unwrap();
+
+        let X_f32 = X.mapv(|v| v as f32);
+        let original = flat.predict(&X_f32.view());
+        let from_serde = restored.predict(&X_f32.view());
+        assert_eq!(
+            original, from_serde,
+            "predictions must match after round-trip"
+        );
+    }
+
+    /// Compact serialization is smaller than the full padded node array.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_compact_smaller_than_padded() {
+        let (X, y) = make_data(150, 8, 77);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(20)
+            .with_seed(77);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&X.view(), &y.view());
+        let flat = FlatForest::from_forest(&forest, 8);
+
+        let compact_bytes = postcard::to_stdvec(&flat).unwrap();
+        let padded_bytes =
+            flat.meta.n_trees as usize * flat.meta.max_tree_size as usize * size_of::<FlatNode>();
+        assert!(
+            compact_bytes.len() < padded_bytes,
+            "compact serde ({} bytes) should be smaller than raw padded layout ({} bytes)",
+            compact_bytes.len(),
+            padded_bytes
+        );
     }
 
     /// Count reachable nodes from root via BFS using explicit child indices.

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -10,28 +10,35 @@ use std::collections::VecDeque;
 ///
 /// Child indices are explicit offsets into the per-tree node slice, so trees
 /// of any shape can be stored without exponential padding.
+///
+/// Field order: traversal-hot fields (`left`, `right`, `feature_index`,
+/// `threshold`) come first, the leaf-only field (`leaf_value`) last.
+/// `is_leaf` was removed — `left < 0` encodes leaf status without redundancy
+/// and without the 3-byte padding hole that `bool` caused before `threshold`.
+///
+/// NOTE: field order is significant for binary serde (e.g. postcard). If you
+/// need binary compatibility with data serialised before this change, a
+/// migration step is required.
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FlatNode {
-    pub feature_index: u32,
-    pub is_leaf: bool,
-    pub threshold: f64,
-    pub leaf_value: f64,
     /// Index of the left child within the tree's node slice, or -1 for leaves.
     pub left: i32,
     /// Index of the right child within the tree's node slice, or -1 for leaves.
     pub right: i32,
+    pub feature_index: u32,
+    pub threshold: f64,
+    pub leaf_value: f64,
 }
 
 impl FlatNode {
     fn dummy_leaf() -> Self {
         FlatNode {
-            feature_index: 0,
-            is_leaf: true,
-            threshold: 0.0,
-            leaf_value: 0.0,
             left: -1,
             right: -1,
+            feature_index: 0,
+            threshold: 0.0,
+            leaf_value: 0.0,
         }
     }
 }
@@ -65,7 +72,7 @@ impl FlatNode {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FlatForest {
     /// Flat node array: length = `n_trees * max_tree_size`.
-    pub nodes: Vec<FlatNode>,
+    pub(crate) nodes: Vec<FlatNode>,
     pub n_trees: usize,
     pub n_features: usize,
     /// Nodes per tree (all trees padded to this size).
@@ -115,30 +122,31 @@ impl FlatForest {
     /// Run inference on a batch of samples.
     ///
     /// Produces the same results as `RandomForest::predict` (mean of per-tree predictions).
+    ///
+    /// The loop order is outer=tree, inner=sample so that each tree's node array
+    /// stays warm in L3 cache while all samples are processed against it, rather
+    /// than re-loading every tree's nodes for every sample.
     pub fn predict(&self, X: &ArrayView2<f64>) -> Array1<f64> {
         let n_samples = X.nrows();
         let mut output = Array1::<f64>::zeros(n_samples);
 
-        for sample in 0..n_samples {
-            let row = X.row(sample);
-            let features = row.as_slice().expect("feature row must be contiguous");
-
-            let mut sum = 0.0f64;
-            for tree_idx in 0..self.n_trees {
-                sum += self.predict_one(tree_idx, features);
+        for tree_idx in 0..self.n_trees {
+            for sample in 0..n_samples {
+                let row = X.row(sample);
+                let features = row.as_slice().expect("feature row must be contiguous");
+                output[sample] += self.predict_one(tree_idx, features);
             }
-            output[sample] = sum / self.n_trees as f64;
         }
 
-        output
+        output / self.n_trees as f64
     }
 
     fn predict_one(&self, tree_idx: usize, features: &[f64]) -> f64 {
         let offset = tree_idx * self.max_tree_size;
         let mut idx = 0usize;
-        loop {
+        for _ in 0..self.max_tree_size {
             let node = &self.nodes[offset + idx];
-            if node.is_leaf {
+            if node.left < 0 {
                 return node.leaf_value;
             }
             if features[node.feature_index as usize] < node.threshold {
@@ -147,6 +155,10 @@ impl FlatForest {
                 idx = node.right as usize;
             }
         }
+        panic!(
+            "predict_one: traversal exceeded max_tree_size ({}); tree may be malformed",
+            self.max_tree_size
+        );
     }
 }
 
@@ -180,12 +192,11 @@ fn fill_bfs(root: &DecisionTreeNode, nodes: &mut [FlatNode]) {
     while let Some((node, idx)) = queue.pop_front() {
         if node.feature_index.is_none() {
             nodes[idx] = FlatNode {
-                feature_index: 0,
-                is_leaf: true,
-                threshold: 0.0,
-                leaf_value: node.label.unwrap(),
                 left: -1,
                 right: -1,
+                feature_index: 0,
+                threshold: 0.0,
+                leaf_value: node.label.unwrap(),
             };
         } else {
             let left_idx = next_slot;
@@ -194,12 +205,11 @@ fn fill_bfs(root: &DecisionTreeNode, nodes: &mut [FlatNode]) {
             next_slot += 1;
 
             nodes[idx] = FlatNode {
-                feature_index: node.feature_index.unwrap() as u32,
-                is_leaf: false,
-                threshold: node.feature_value.unwrap(),
-                leaf_value: 0.0,
                 left: left_idx as i32,
                 right: right_idx as i32,
+                feature_index: node.feature_index.unwrap() as u32,
+                threshold: node.feature_value.unwrap(),
+                leaf_value: 0.0,
             };
 
             queue.push_back((node.left_child.as_ref().unwrap(), left_idx));

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -105,6 +105,7 @@ pub struct FlatForest {
     pub(crate) nodes: Vec<FlatNode>,
     /// Number of real (non-padding) nodes in each tree; computed once in
     /// `from_forest` alongside `max_tree_size` and reused by serde.
+    #[allow(unused, reason = "serde needs this for round-trip validation")]
     pub(crate) tree_sizes: Vec<u32>,
     pub meta: ForestMeta,
 }
@@ -238,7 +239,7 @@ mod serde_impl {
                 }
                 fn visit_bytes<E: Error>(self, v: &[u8]) -> Result<Self::Value, E> {
                     let node_size = std::mem::size_of::<FlatNode>();
-                    if v.len() % node_size != 0 {
+                    if !v.len().is_multiple_of(node_size) {
                         return Err(E::custom(format!(
                             "expected a multiple of {node_size} bytes (FlatNode size), got {}",
                             v.len()
@@ -336,216 +337,6 @@ mod serde_impl {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::RandomForest;
-    use crate::forest::RandomForestParameters;
-    use ndarray::Array2;
-    use ndarray_rand::RandomExt;
-    use ndarray_rand::rand_distr::Uniform;
-    use rand::SeedableRng;
-    use rand::rngs::StdRng;
-    use std::mem::size_of;
-
-    fn make_data(
-        n_samples: usize,
-        n_features: usize,
-        seed: u64,
-    ) -> (Array2<f64>, ndarray::Array1<f64>) {
-        let mut rng = StdRng::seed_from_u64(seed);
-        let X = Array2::random_using(
-            (n_samples, n_features),
-            Uniform::new(0.0, 1.0).unwrap(),
-            &mut rng,
-        );
-        let y = X.column(0).to_owned();
-        (X, y)
-    }
-
-    /// nodes.len() must always equal n_trees * max_tree_size (test #16).
-    #[test]
-    fn nodes_length_invariant() {
-        let (X, y) = make_data(120, 6, 16);
-        let params = RandomForestParameters::default()
-            .with_n_estimators(15)
-            .with_seed(16);
-        let mut forest = RandomForest::new(params);
-        forest.fit(&X.view(), &y.view());
-
-        let flat = FlatForest::from_forest(&forest, 6);
-        assert_eq!(
-            flat.nodes.len(),
-            flat.n_trees as usize * flat.max_tree_size as usize,
-            "nodes.len() should equal n_trees * max_tree_size"
-        );
-    }
-
-    /// Every slot beyond a tree's real BFS footprint must be a dummy leaf (test #15).
-    #[test]
-    fn padding_nodes_are_leaves() {
-        let (X, y) = make_data(150, 8, 15);
-        let params = RandomForestParameters::default()
-            .with_n_estimators(10)
-            .with_seed(15);
-        let mut forest = RandomForest::new(params);
-        forest.fit(&X.view(), &y.view());
-
-        let flat = FlatForest::from_forest(&forest, 8);
-        let n_trees = flat.n_trees as usize;
-        let max_tree_size = flat.max_tree_size as usize;
-
-        for tree_idx in 0..n_trees {
-            let offset = tree_idx * max_tree_size;
-            let tree_nodes = &flat.nodes[offset..offset + max_tree_size];
-            let real_count = count_bfs_nodes(tree_nodes);
-            for i in real_count..max_tree_size {
-                assert!(
-                    tree_nodes[i].left < 0,
-                    "tree {tree_idx}, slot {i} (beyond real size {real_count}): expected dummy leaf, got left={}",
-                    tree_nodes[i].left
-                );
-            }
-        }
-    }
-
-    /// `max_tree_size` must equal the actual maximum node count, not the BFS positional
-    /// formula `2^(max_depth+1) - 1` (test #3). For unconstrained trees deep enough that
-    /// the positional layout would differ, the two values must diverge.
-    #[test]
-    fn max_tree_size_is_actual_count_not_bfs_formula() {
-        let (X, y) = make_data(150, 6, 42);
-        let params = RandomForestParameters::default()
-            .with_n_estimators(10)
-            .with_seed(42);
-        let mut forest = RandomForest::new(params);
-        forest.fit(&X.view(), &y.view());
-
-        let flat = FlatForest::from_forest(&forest, 6);
-
-        // Independent recomputation of max node count using the private helper.
-        let expected_max = forest
-            .trees()
-            .iter()
-            .map(|t| count_nodes(t.root()))
-            .max()
-            .unwrap();
-        assert_eq!(
-            flat.max_tree_size as usize, expected_max,
-            "max_tree_size should equal the actual max node count across trees"
-        );
-
-        // For trees with max_depth >= 4, the positional BFS layout would require
-        // at least 2^5 - 1 = 31 nodes, whereas typical trees with the same depth
-        // but sparse structure will have far fewer. Assert we use the compact count.
-        let bfs_formula = (1usize << (flat.max_depth as usize + 1)).saturating_sub(1);
-        if flat.max_depth >= 4 {
-            assert!(
-                (flat.max_tree_size as usize) < bfs_formula,
-                "max_tree_size ({}) should be less than BFS formula ({}) for depth-{} trees",
-                flat.max_tree_size,
-                bfs_formula,
-                flat.max_depth
-            );
-        }
-    }
-
-    /// Every padding node beyond a tree's real BFS footprint must have `value == 0.0` (test #5).
-    /// This verifies that `FlatNode::dummy_leaf()` initialises `value` to zero, so padding
-    /// slots cannot accidentally contribute non-zero predictions if the loop bound is wrong.
-    #[test]
-    fn dummy_leaf_value_is_zero() {
-        let (X, y) = make_data(150, 8, 50);
-        let params = RandomForestParameters::default()
-            .with_n_estimators(10)
-            .with_seed(50);
-        let mut forest = RandomForest::new(params);
-        forest.fit(&X.view(), &y.view());
-
-        let flat = FlatForest::from_forest(&forest, 8);
-        let max_tree_size = flat.max_tree_size as usize;
-
-        for tree_idx in 0..flat.n_trees as usize {
-            let offset = tree_idx * max_tree_size;
-            let tree_nodes = &flat.nodes[offset..offset + max_tree_size];
-            let real_count = count_bfs_nodes(tree_nodes);
-            for i in real_count..max_tree_size {
-                assert_eq!(
-                    tree_nodes[i].value, 0.0,
-                    "tree {tree_idx}, padding slot {i}: expected value=0.0"
-                );
-            }
-        }
-    }
-
-    /// Serializing then deserializing a FlatForest produces the same predictions.
-    #[cfg(feature = "serde")]
-    #[test]
-    fn serde_round_trip_predictions() {
-        let (X, y) = make_data(150, 6, 99);
-        let params = RandomForestParameters::default()
-            .with_n_estimators(10)
-            .with_seed(99);
-        let mut forest = RandomForest::new(params);
-        forest.fit(&X.view(), &y.view());
-        let flat = FlatForest::from_forest(&forest, 6);
-
-        let bytes = postcard::to_stdvec(&flat).unwrap();
-        let restored: FlatForest = postcard::from_bytes(&bytes).unwrap();
-
-        let X_f32 = X.mapv(|v| v as f32);
-        let original = flat.predict(&X_f32.view());
-        let from_serde = restored.predict(&X_f32.view());
-        assert_eq!(
-            original, from_serde,
-            "predictions must match after round-trip"
-        );
-    }
-
-    /// Compact serialization is smaller than the full padded node array.
-    #[cfg(feature = "serde")]
-    #[test]
-    fn serde_compact_smaller_than_padded() {
-        let (X, y) = make_data(150, 8, 77);
-        let params = RandomForestParameters::default()
-            .with_n_estimators(20)
-            .with_seed(77);
-        let mut forest = RandomForest::new(params);
-        forest.fit(&X.view(), &y.view());
-        let flat = FlatForest::from_forest(&forest, 8);
-
-        let compact_bytes = postcard::to_stdvec(&flat).unwrap();
-        let padded_bytes =
-            flat.meta.n_trees as usize * flat.meta.max_tree_size as usize * size_of::<FlatNode>();
-        assert!(
-            compact_bytes.len() < padded_bytes,
-            "compact serde ({} bytes) should be smaller than raw padded layout ({} bytes)",
-            compact_bytes.len(),
-            padded_bytes
-        );
-    }
-
-    /// Count reachable nodes from root via BFS using explicit child indices.
-    fn count_bfs_nodes(nodes: &[FlatNode]) -> usize {
-        use std::collections::VecDeque;
-        let mut queue = VecDeque::new();
-        queue.push_back(0usize);
-        let mut count = 0;
-        while let Some(idx) = queue.pop_front() {
-            if idx >= nodes.len() {
-                break;
-            }
-            count += 1;
-            let node = &nodes[idx];
-            if node.left >= 0 {
-                queue.push_back(node.left as usize);
-                queue.push_back(node.right as usize);
-            }
-        }
-        count
-    }
-}
-
 /// Recursively compute the depth of a node (0 = leaf, 1 = one split level, …).
 fn node_depth(node: &DecisionTreeNode) -> usize {
     if node.feature_index.is_none() {
@@ -626,5 +417,225 @@ fn fill_bfs(root: &DecisionTreeNode, nodes: &mut [FlatNode]) {
                     as f32,
             };
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RandomForest;
+    use crate::forest::RandomForestParameters;
+    use ndarray::Array2;
+    use ndarray_rand::RandomExt;
+    use ndarray_rand::rand_distr::Uniform;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+    use std::mem::size_of;
+
+    fn make_data(
+        n_samples: usize,
+        n_features: usize,
+        seed: u64,
+    ) -> (Array2<f64>, ndarray::Array1<f64>) {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let X = Array2::random_using(
+            (n_samples, n_features),
+            Uniform::new(0.0, 1.0).unwrap(),
+            &mut rng,
+        );
+        let y = X.column(0).to_owned();
+        (X, y)
+    }
+
+    /// nodes.len() must always equal n_trees * max_tree_size (test #16).
+    #[test]
+    fn nodes_length_invariant() {
+        let (X, y) = make_data(120, 6, 16);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(15)
+            .with_seed(16);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&X.view(), &y.view());
+
+        let flat = FlatForest::from_forest(&forest, 6);
+        assert_eq!(
+            flat.nodes.len(),
+            flat.n_trees as usize * flat.max_tree_size as usize,
+            "nodes.len() should equal n_trees * max_tree_size"
+        );
+    }
+
+    /// Every slot beyond a tree's real BFS footprint must be a dummy leaf (test #15).
+    #[test]
+    fn padding_nodes_are_leaves() {
+        let (X, y) = make_data(150, 8, 15);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(10)
+            .with_seed(15);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&X.view(), &y.view());
+
+        let flat = FlatForest::from_forest(&forest, 8);
+        let n_trees = flat.n_trees as usize;
+        let max_tree_size = flat.max_tree_size as usize;
+
+        for tree_idx in 0..n_trees {
+            let offset = tree_idx * max_tree_size;
+            let tree_nodes = &flat.nodes[offset..offset + max_tree_size];
+            let real_count = count_bfs_nodes(tree_nodes);
+            for (i, node) in tree_nodes
+                .iter()
+                .enumerate()
+                .take(max_tree_size)
+                .skip(real_count)
+            {
+                assert!(
+                    node.left < 0,
+                    "tree {tree_idx}, slot {i} (beyond real size {real_count}): expected dummy leaf, got left={}",
+                    node.left
+                );
+            }
+        }
+    }
+
+    /// `max_tree_size` must equal the actual maximum node count, not the BFS positional
+    /// formula `2^(max_depth+1) - 1` (test #3). For unconstrained trees deep enough that
+    /// the positional layout would differ, the two values must diverge.
+    #[test]
+    fn max_tree_size_is_actual_count_not_bfs_formula() {
+        let (X, y) = make_data(150, 6, 42);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(10)
+            .with_seed(42);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&X.view(), &y.view());
+
+        let flat = FlatForest::from_forest(&forest, 6);
+
+        // Independent recomputation of max node count using the private helper.
+        let expected_max = forest
+            .trees()
+            .iter()
+            .map(|t| count_nodes(t.root()))
+            .max()
+            .unwrap();
+        assert_eq!(
+            flat.max_tree_size as usize, expected_max,
+            "max_tree_size should equal the actual max node count across trees"
+        );
+
+        // For trees with max_depth >= 4, the positional BFS layout would require
+        // at least 2^5 - 1 = 31 nodes, whereas typical trees with the same depth
+        // but sparse structure will have far fewer. Assert we use the compact count.
+        let bfs_formula = (1usize << (flat.max_depth as usize + 1)).saturating_sub(1);
+        if flat.max_depth >= 4 {
+            assert!(
+                (flat.max_tree_size as usize) < bfs_formula,
+                "max_tree_size ({}) should be less than BFS formula ({}) for depth-{} trees",
+                flat.max_tree_size,
+                bfs_formula,
+                flat.max_depth
+            );
+        }
+    }
+
+    /// Every padding node beyond a tree's real BFS footprint must have `value == 0.0` (test #5).
+    /// This verifies that `FlatNode::dummy_leaf()` initialises `value` to zero, so padding
+    /// slots cannot accidentally contribute non-zero predictions if the loop bound is wrong.
+    #[test]
+    fn dummy_leaf_value_is_zero() {
+        let (X, y) = make_data(150, 8, 50);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(10)
+            .with_seed(50);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&X.view(), &y.view());
+
+        let flat = FlatForest::from_forest(&forest, 8);
+        let max_tree_size = flat.max_tree_size as usize;
+
+        for tree_idx in 0..flat.n_trees as usize {
+            let offset = tree_idx * max_tree_size;
+            let tree_nodes = &flat.nodes[offset..offset + max_tree_size];
+            let real_count = count_bfs_nodes(tree_nodes);
+            for (i, node) in tree_nodes
+                .iter()
+                .enumerate()
+                .take(max_tree_size)
+                .skip(real_count)
+            {
+                assert_eq!(
+                    node.value, 0.0,
+                    "tree {tree_idx}, padding slot {i}: expected value=0.0"
+                );
+            }
+        }
+    }
+
+    /// Serializing then deserializing a FlatForest produces the same predictions.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_round_trip_predictions() {
+        let (X, y) = make_data(150, 6, 99);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(10)
+            .with_seed(99);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&X.view(), &y.view());
+        let flat = FlatForest::from_forest(&forest, 6);
+
+        let bytes = postcard::to_stdvec(&flat).unwrap();
+        let restored: FlatForest = postcard::from_bytes(&bytes).unwrap();
+
+        let X_f32 = X.mapv(|v| v as f32);
+        let original = flat.predict(&X_f32.view());
+        let from_serde = restored.predict(&X_f32.view());
+        assert_eq!(
+            original, from_serde,
+            "predictions must match after round-trip"
+        );
+    }
+
+    /// Compact serialization is smaller than the full padded node array.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_compact_smaller_than_padded() {
+        let (X, y) = make_data(150, 8, 77);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(20)
+            .with_seed(77);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&X.view(), &y.view());
+        let flat = FlatForest::from_forest(&forest, 8);
+
+        let compact_bytes = postcard::to_stdvec(&flat).unwrap();
+        let padded_bytes =
+            flat.meta.n_trees as usize * flat.meta.max_tree_size as usize * size_of::<FlatNode>();
+        assert!(
+            compact_bytes.len() < padded_bytes,
+            "compact serde ({} bytes) should be smaller than raw padded layout ({} bytes)",
+            compact_bytes.len(),
+            padded_bytes
+        );
+    }
+
+    /// Count reachable nodes from root via BFS using explicit child indices.
+    fn count_bfs_nodes(nodes: &[FlatNode]) -> usize {
+        use std::collections::VecDeque;
+        let mut queue = VecDeque::new();
+        queue.push_back(0usize);
+        let mut count = 0;
+        while let Some(idx) = queue.pop_front() {
+            if idx >= nodes.len() {
+                break;
+            }
+            count += 1;
+            let node = &nodes[idx];
+            if node.left >= 0 {
+                queue.push_back(node.left as usize);
+                queue.push_back(node.right as usize);
+            }
+        }
+        count
     }
 }

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -1,17 +1,26 @@
 use crate::forest::RandomForest;
 use crate::tree::DecisionTreeNode;
 use ndarray::{Array1, ArrayView2};
+use std::collections::VecDeque;
 
-/// A single node in a BFS-ordered flat tree.
+/// A single node in a flat tree stored in BFS visit order.
 ///
-/// Internal nodes use `feature_index` and `threshold`; leaf nodes use `leaf_value`.
-/// The BFS layout: node at index `i` has left child at `2i + 1`, right child at `2i + 2`.
-#[derive(Clone, Debug)]
+/// Internal nodes use `feature_index`, `threshold`, `left`, and `right`.
+/// Leaf nodes use `leaf_value`; `left` and `right` are -1.
+///
+/// Child indices are explicit offsets into the per-tree node slice, so trees
+/// of any shape can be stored without exponential padding.
+#[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FlatNode {
     pub feature_index: u32,
     pub is_leaf: bool,
     pub threshold: f64,
     pub leaf_value: f64,
+    /// Index of the left child within the tree's node slice, or -1 for leaves.
+    pub left: i32,
+    /// Index of the right child within the tree's node slice, or -1 for leaves.
+    pub right: i32,
 }
 
 impl FlatNode {
@@ -21,17 +30,25 @@ impl FlatNode {
             is_leaf: true,
             threshold: 0.0,
             leaf_value: 0.0,
+            left: -1,
+            right: -1,
         }
     }
 }
 
-/// A random forest stored as a flat BFS-ordered array of nodes.
+/// A random forest stored as a flat array of nodes with explicit child indices.
 ///
-/// All trees are padded to `max_tree_size` nodes so any tree can be indexed as
-/// `nodes[tree_idx * max_tree_size + node_idx]`.
+/// Each tree occupies a contiguous slice of `max_tree_size` nodes:
+/// `nodes[tree_idx * max_tree_size .. (tree_idx + 1) * max_tree_size]`.
 ///
-/// This representation enables both cache-friendly CPU inference and direct GPU upload.
-#[derive(Clone, Debug)]
+/// Node 0 of each slice is the root. Internal nodes store explicit `left`/`right`
+/// indices (relative to the tree's slice start). Shorter trees are padded with
+/// dummy leaf nodes that are never reached during inference.
+///
+/// This representation enables cache-friendly CPU inference and direct GPU upload
+/// without exponential memory blowup for deep, sparse trees.
+#[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FlatForest {
     /// Flat node array: length = `n_trees * max_tree_size`.
     pub nodes: Vec<FlatNode>,
@@ -39,7 +56,7 @@ pub struct FlatForest {
     pub n_features: usize,
     /// Nodes per tree (all trees padded to this size).
     pub max_tree_size: usize,
-    /// Maximum depth across all trees.
+    /// Maximum depth across all trees (used as a GPU traversal bound).
     pub max_depth: usize,
 }
 
@@ -52,21 +69,24 @@ impl FlatForest {
         let n_trees = trees.len();
         assert!(n_trees > 0, "Forest must have at least one tree");
 
-        // Compute the max depth across all trees.
         let max_depth = trees
             .iter()
             .map(|t| node_depth(t.root()))
             .max()
             .unwrap_or(0);
 
-        // BFS-complete tree needs 2^(depth+1) - 1 nodes.
-        let max_tree_size = (1usize << (max_depth + 1)).saturating_sub(1);
+        // Allocate only as many slots as the largest tree actually needs.
+        let max_tree_size = trees
+            .iter()
+            .map(|t| count_nodes(t.root()))
+            .max()
+            .unwrap_or(1);
 
         let mut nodes = vec![FlatNode::dummy_leaf(); n_trees * max_tree_size];
 
         for (tree_idx, tree) in trees.iter().enumerate() {
             let offset = tree_idx * max_tree_size;
-            fill_bfs(tree.root(), &mut nodes[offset..offset + max_tree_size], 0);
+            fill_bfs(tree.root(), &mut nodes[offset..offset + max_tree_size]);
         }
 
         FlatForest {
@@ -108,15 +128,15 @@ impl FlatForest {
                 return node.leaf_value;
             }
             if features[node.feature_index as usize] < node.threshold {
-                idx = 2 * idx + 1; // left
+                idx = node.left as usize;
             } else {
-                idx = 2 * idx + 2; // right
+                idx = node.right as usize;
             }
         }
     }
 }
 
-/// Recursively compute the depth of a node (0 = leaf, 1 = one level of splits, …).
+/// Recursively compute the depth of a node (0 = leaf, 1 = one split level, …).
 fn node_depth(node: &DecisionTreeNode) -> usize {
     if node.feature_index.is_none() {
         0
@@ -126,26 +146,50 @@ fn node_depth(node: &DecisionTreeNode) -> usize {
     }
 }
 
-/// Fill BFS-ordered `nodes` slice starting at `index` by recursively visiting `node`.
-fn fill_bfs(node: &DecisionTreeNode, nodes: &mut [FlatNode], index: usize) {
-    if index >= nodes.len() {
-        return;
-    }
+/// Count the total number of nodes in the subtree rooted at `node`.
+fn count_nodes(node: &DecisionTreeNode) -> usize {
     if node.feature_index.is_none() {
-        nodes[index] = FlatNode {
-            feature_index: 0,
-            is_leaf: true,
-            threshold: 0.0,
-            leaf_value: node.label.unwrap(),
-        };
+        1
     } else {
-        nodes[index] = FlatNode {
-            feature_index: node.feature_index.unwrap() as u32,
-            is_leaf: false,
-            threshold: node.feature_value.unwrap(),
-            leaf_value: 0.0,
-        };
-        fill_bfs(node.left_child.as_ref().unwrap(), nodes, 2 * index + 1);
-        fill_bfs(node.right_child.as_ref().unwrap(), nodes, 2 * index + 2);
+        1 + count_nodes(node.left_child.as_ref().unwrap())
+            + count_nodes(node.right_child.as_ref().unwrap())
+    }
+}
+
+/// Fill `nodes` with the tree rooted at `root` in BFS order, storing explicit
+/// child indices in each internal node.
+fn fill_bfs(root: &DecisionTreeNode, nodes: &mut [FlatNode]) {
+    let mut queue: VecDeque<(&DecisionTreeNode, usize)> = VecDeque::new();
+    queue.push_back((root, 0));
+    let mut next_slot = 1usize;
+
+    while let Some((node, idx)) = queue.pop_front() {
+        if node.feature_index.is_none() {
+            nodes[idx] = FlatNode {
+                feature_index: 0,
+                is_leaf: true,
+                threshold: 0.0,
+                leaf_value: node.label.unwrap(),
+                left: -1,
+                right: -1,
+            };
+        } else {
+            let left_idx = next_slot;
+            next_slot += 1;
+            let right_idx = next_slot;
+            next_slot += 1;
+
+            nodes[idx] = FlatNode {
+                feature_index: node.feature_index.unwrap() as u32,
+                is_leaf: false,
+                threshold: node.feature_value.unwrap(),
+                leaf_value: 0.0,
+                left: left_idx as i32,
+                right: right_idx as i32,
+            };
+
+            queue.push_back((node.left_child.as_ref().unwrap(), left_idx));
+            queue.push_back((node.right_child.as_ref().unwrap(), right_idx));
+        }
     }
 }

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -1,0 +1,151 @@
+use crate::forest::RandomForest;
+use crate::tree::DecisionTreeNode;
+use ndarray::{Array1, ArrayView2};
+
+/// A single node in a BFS-ordered flat tree.
+///
+/// Internal nodes use `feature_index` and `threshold`; leaf nodes use `leaf_value`.
+/// The BFS layout: node at index `i` has left child at `2i + 1`, right child at `2i + 2`.
+#[derive(Clone, Debug)]
+pub struct FlatNode {
+    pub feature_index: u32,
+    pub is_leaf: bool,
+    pub threshold: f64,
+    pub leaf_value: f64,
+}
+
+impl FlatNode {
+    fn dummy_leaf() -> Self {
+        FlatNode {
+            feature_index: 0,
+            is_leaf: true,
+            threshold: 0.0,
+            leaf_value: 0.0,
+        }
+    }
+}
+
+/// A random forest stored as a flat BFS-ordered array of nodes.
+///
+/// All trees are padded to `max_tree_size` nodes so any tree can be indexed as
+/// `nodes[tree_idx * max_tree_size + node_idx]`.
+///
+/// This representation enables both cache-friendly CPU inference and direct GPU upload.
+#[derive(Clone, Debug)]
+pub struct FlatForest {
+    /// Flat node array: length = `n_trees * max_tree_size`.
+    pub nodes: Vec<FlatNode>,
+    pub n_trees: usize,
+    pub n_features: usize,
+    /// Nodes per tree (all trees padded to this size).
+    pub max_tree_size: usize,
+    /// Maximum depth across all trees.
+    pub max_depth: usize,
+}
+
+impl FlatForest {
+    /// Build a `FlatForest` from a trained `RandomForest`.
+    ///
+    /// `n_features` must match the number of features the forest was trained on.
+    pub fn from_forest(forest: &RandomForest, n_features: usize) -> Self {
+        let trees = forest.trees();
+        let n_trees = trees.len();
+        assert!(n_trees > 0, "Forest must have at least one tree");
+
+        // Compute the max depth across all trees.
+        let max_depth = trees
+            .iter()
+            .map(|t| node_depth(t.root()))
+            .max()
+            .unwrap_or(0);
+
+        // BFS-complete tree needs 2^(depth+1) - 1 nodes.
+        let max_tree_size = (1usize << (max_depth + 1)).saturating_sub(1);
+
+        let mut nodes = vec![FlatNode::dummy_leaf(); n_trees * max_tree_size];
+
+        for (tree_idx, tree) in trees.iter().enumerate() {
+            let offset = tree_idx * max_tree_size;
+            fill_bfs(tree.root(), &mut nodes[offset..offset + max_tree_size], 0);
+        }
+
+        FlatForest {
+            nodes,
+            n_trees,
+            n_features,
+            max_tree_size,
+            max_depth,
+        }
+    }
+
+    /// Run inference on a batch of samples.
+    ///
+    /// Produces the same results as `RandomForest::predict` (mean of per-tree predictions).
+    pub fn predict(&self, X: &ArrayView2<f64>) -> Array1<f64> {
+        let n_samples = X.nrows();
+        let mut output = Array1::<f64>::zeros(n_samples);
+
+        for sample in 0..n_samples {
+            let row = X.row(sample);
+            let features = row.as_slice().expect("feature row must be contiguous");
+
+            let mut sum = 0.0f64;
+            for tree_idx in 0..self.n_trees {
+                sum += self.predict_one(tree_idx, features);
+            }
+            output[sample] = sum / self.n_trees as f64;
+        }
+
+        output
+    }
+
+    fn predict_one(&self, tree_idx: usize, features: &[f64]) -> f64 {
+        let offset = tree_idx * self.max_tree_size;
+        let mut idx = 0usize;
+        loop {
+            let node = &self.nodes[offset + idx];
+            if node.is_leaf {
+                return node.leaf_value;
+            }
+            if features[node.feature_index as usize] < node.threshold {
+                idx = 2 * idx + 1; // left
+            } else {
+                idx = 2 * idx + 2; // right
+            }
+        }
+    }
+}
+
+/// Recursively compute the depth of a node (0 = leaf, 1 = one level of splits, …).
+fn node_depth(node: &DecisionTreeNode) -> usize {
+    if node.feature_index.is_none() {
+        0
+    } else {
+        1 + node_depth(node.left_child.as_ref().unwrap())
+            .max(node_depth(node.right_child.as_ref().unwrap()))
+    }
+}
+
+/// Fill BFS-ordered `nodes` slice starting at `index` by recursively visiting `node`.
+fn fill_bfs(node: &DecisionTreeNode, nodes: &mut [FlatNode], index: usize) {
+    if index >= nodes.len() {
+        return;
+    }
+    if node.feature_index.is_none() {
+        nodes[index] = FlatNode {
+            feature_index: 0,
+            is_leaf: true,
+            threshold: 0.0,
+            leaf_value: node.label.unwrap(),
+        };
+    } else {
+        nodes[index] = FlatNode {
+            feature_index: node.feature_index.unwrap() as u32,
+            is_leaf: false,
+            threshold: node.feature_value.unwrap(),
+            leaf_value: 0.0,
+        };
+        fill_bfs(node.left_child.as_ref().unwrap(), nodes, 2 * index + 1);
+        fill_bfs(node.right_child.as_ref().unwrap(), nodes, 2 * index + 2);
+    }
+}

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -112,7 +112,10 @@ impl FlatForest {
     /// Build a `FlatForest` from a trained `RandomForest`.
     ///
     /// `n_features` must match the number of features the forest was trained on.
+    /// Passing an incorrect value will produce silently wrong predictions,
+    /// because `n_features` is used as the GPU shader's feature-indexing stride.
     pub fn from_forest(forest: &RandomForest, n_features: usize) -> Self {
+        assert!(n_features > 0, "n_features must be > 0");
         let trees = forest.trees();
         let n_trees = trees.len();
         assert!(n_trees > 0, "Forest must have at least one tree");
@@ -154,17 +157,24 @@ impl FlatForest {
     /// GPU inference. The per-tree leaf values (f32) are accumulated in f64 and
     /// the final mean is returned as `Array1<f64>`.
     ///
+    /// `X` may be in any memory layout (row-major, column-major, or
+    /// non-contiguous). The method converts to C-order internally; if `X` is
+    /// already row-major this is a zero-copy borrow.
+    ///
     /// The loop order is outer=tree, inner=sample so that each tree's node array
     /// stays warm in L3 cache while all samples are processed against it, rather
     /// than re-loading every tree's nodes for every sample.
     pub fn predict(&self, X: &ArrayView2<f32>) -> Array1<f64> {
-        let n_samples = X.nrows();
+        let X_c = X.as_standard_layout();
+        let n_samples = X_c.nrows();
         let mut output = Array1::<f64>::zeros(n_samples);
 
         for tree_idx in 0..self.meta.n_trees as usize {
             for sample in 0..n_samples {
-                let row = X.row(sample);
-                let features = row.as_slice().expect("feature row must be contiguous");
+                let row = X_c.row(sample);
+                let features = row
+                    .as_slice()
+                    .expect("standard layout is always contiguous");
                 output[sample] += self.predict_one(tree_idx, features);
             }
         }
@@ -186,8 +196,11 @@ impl FlatForest {
                 idx = node.right as usize;
             }
         }
-        panic!(
-            "predict_one: traversal exceeded max_depth ({}); tree may be malformed",
+        // max_depth is computed from node_depth() during from_forest, so max_depth + 1
+        // iterations always reach a leaf for a correctly built tree. Reaching here
+        // indicates a bug in from_forest or fill_bfs.
+        unreachable!(
+            "predict_one: traversal exceeded max_depth={}",
             self.meta.max_depth
         );
     }
@@ -360,8 +373,14 @@ fn node_depth(node: &DecisionTreeNode) -> usize {
     if node.feature_index.is_none() {
         0
     } else {
-        1 + node_depth(node.left_child.as_ref().unwrap())
-            .max(node_depth(node.right_child.as_ref().unwrap()))
+        1 + node_depth(
+            node.left_child
+                .as_ref()
+                .expect("internal node (feature_index is Some) must have a left child"),
+        )
+        .max(node_depth(node.right_child.as_ref().expect(
+            "internal node (feature_index is Some) must have a right child",
+        )))
     }
 }
 
@@ -370,8 +389,15 @@ fn count_nodes(node: &DecisionTreeNode) -> usize {
     if node.feature_index.is_none() {
         1
     } else {
-        1 + count_nodes(node.left_child.as_ref().unwrap())
-            + count_nodes(node.right_child.as_ref().unwrap())
+        1 + count_nodes(
+            node.left_child
+                .as_ref()
+                .expect("internal node (feature_index is Some) must have a left child"),
+        ) + count_nodes(
+            node.right_child
+                .as_ref()
+                .expect("internal node (feature_index is Some) must have a right child"),
+        )
     }
 }
 
@@ -393,17 +419,33 @@ fn fill_bfs(root: &DecisionTreeNode, nodes: &mut [FlatNode]) {
                 left: left_idx as i32,
                 right: right_idx as i32,
                 feature_index: feature_index as u32,
-                value: node.feature_value.unwrap() as f32,
+                value: node
+                    .feature_value
+                    .expect("internal node (feature_index is Some) must have a feature_value")
+                    as f32,
             };
 
-            queue.push_back((node.left_child.as_ref().unwrap(), left_idx));
-            queue.push_back((node.right_child.as_ref().unwrap(), right_idx));
+            queue.push_back((
+                node.left_child
+                    .as_ref()
+                    .expect("internal node (feature_index is Some) must have a left child"),
+                left_idx,
+            ));
+            queue.push_back((
+                node.right_child
+                    .as_ref()
+                    .expect("internal node (feature_index is Some) must have a right child"),
+                right_idx,
+            ));
         } else {
             nodes[idx] = FlatNode {
                 left: -1,
                 right: -1,
                 feature_index: 0,
-                value: node.label.unwrap() as f32,
+                value: node
+                    .label
+                    .expect("leaf node (feature_index is None) must have a label")
+                    as f32,
             };
         }
     }

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -36,17 +36,31 @@ impl FlatNode {
     }
 }
 
-/// A random forest stored as a flat array of nodes with explicit child indices.
+/// A [`RandomForest`] converted to a flat, contiguous array for fast inference.
 ///
-/// Each tree occupies a contiguous slice of `max_tree_size` nodes:
-/// `nodes[tree_idx * max_tree_size .. (tree_idx + 1) * max_tree_size]`.
+/// This is the bridge between a trained forest and GPU execution. Convert once
+/// with [`FlatForest::from_forest`], then either call [`FlatForest::predict`]
+/// for CPU inference or pass it to [`GpuForest::from_flat_forest`] to run on
+/// the GPU.
 ///
-/// Node 0 of each slice is the root. Internal nodes store explicit `left`/`right`
-/// indices (relative to the tree's slice start). Shorter trees are padded with
-/// dummy leaf nodes that are never reached during inference.
+/// ```rust
+/// use biosphere::{FlatForest, RandomForest, RandomForestParameters};
+/// use ndarray::array;
 ///
-/// This representation enables cache-friendly CPU inference and direct GPU upload
-/// without exponential memory blowup for deep, sparse trees.
+/// let X = array![[0.0, 1.0], [1.0, 0.0]];
+/// let y = array![0.0, 1.0];
+/// let mut forest = RandomForest::new(RandomForestParameters::default());
+/// forest.fit(&X.view(), &y.view());
+///
+/// let flat = FlatForest::from_forest(&forest, X.ncols());
+/// let predictions = flat.predict(&X.view()); // identical to forest.predict()
+/// ```
+///
+/// Internally, each tree is stored in BFS order with explicit child indices so
+/// deep, sparse trees (common in practice) don't require exponential padding.
+///
+/// [`GpuForest::from_flat_forest`]: crate::gpu::GpuForest::from_flat_forest
+/// [`RandomForest`]: crate::RandomForest
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FlatForest {

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -79,16 +79,17 @@ impl FlatNode {
 /// forest.fit(&X.view(), &y.view());
 ///
 /// let flat = FlatForest::from_forest(&forest, X.ncols());
-/// let predictions = flat.predict(&X.view()); // comparable to forest.predict()
+/// let X_f32 = X.mapv(|v| v as f32);
+/// let predictions = flat.predict(&X_f32.view()); // comparable to forest.predict()
 /// ```
 ///
 /// Internally, each tree is stored in BFS order with explicit child indices so
 /// deep, sparse trees (common in practice) don't require exponential padding.
 ///
-/// All thresholds and leaf values are stored as `f32`. CPU inference casts
-/// feature values to `f32` before comparison so that split decisions are
-/// identical to GPU inference. Results are accumulated in `f64` and returned
-/// as `f64` for API consistency with [`RandomForest::predict`].
+/// All thresholds and leaf values are stored as `f32`. Features must be passed
+/// as `f32` so that split decisions are identical to GPU inference. Results are
+/// accumulated in `f64` and returned as `f64` for API consistency with
+/// [`RandomForest::predict`].
 ///
 /// [`GpuForest::from_flat_forest`]: crate::gpu::GpuForest::from_flat_forest
 /// [`RandomForest`]: crate::RandomForest
@@ -149,14 +150,14 @@ impl FlatForest {
 
     /// Run inference on a batch of samples.
     ///
-    /// Feature values are cast to `f32` internally so that split decisions are
-    /// identical to GPU inference. The per-tree leaf values (f32) are accumulated
-    /// in f64 and the final mean is returned as `Array1<f64>`.
+    /// Features must be `f32` to match the precision of stored thresholds and
+    /// GPU inference. The per-tree leaf values (f32) are accumulated in f64 and
+    /// the final mean is returned as `Array1<f64>`.
     ///
     /// The loop order is outer=tree, inner=sample so that each tree's node array
     /// stays warm in L3 cache while all samples are processed against it, rather
     /// than re-loading every tree's nodes for every sample.
-    pub fn predict(&self, X: &ArrayView2<f64>) -> Array1<f64> {
+    pub fn predict(&self, X: &ArrayView2<f32>) -> Array1<f64> {
         let n_samples = X.nrows();
         let mut output = Array1::<f64>::zeros(n_samples);
 
@@ -171,7 +172,7 @@ impl FlatForest {
         output / self.meta.n_trees as f64
     }
 
-    fn predict_one(&self, tree_idx: usize, features: &[f64]) -> f64 {
+    fn predict_one(&self, tree_idx: usize, features: &[f32]) -> f64 {
         let offset = tree_idx * self.meta.max_tree_size as usize;
         let mut idx = 0usize;
         for _ in 0..self.meta.max_tree_size as usize {

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -193,6 +193,91 @@ impl FlatForest {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RandomForest;
+    use crate::forest::RandomForestParameters;
+    use ndarray::Array2;
+    use ndarray_rand::RandomExt;
+    use ndarray_rand::rand_distr::Uniform;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    fn make_data(n_samples: usize, n_features: usize, seed: u64) -> (Array2<f64>, ndarray::Array1<f64>) {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let X = Array2::random_using((n_samples, n_features), Uniform::new(0.0, 1.0).unwrap(), &mut rng);
+        let y = X.column(0).to_owned();
+        (X, y)
+    }
+
+    /// nodes.len() must always equal n_trees * max_tree_size (test #16).
+    #[test]
+    fn nodes_length_invariant() {
+        let (X, y) = make_data(120, 6, 16);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(15)
+            .with_seed(16);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&X.view(), &y.view());
+
+        let flat = FlatForest::from_forest(&forest, 6);
+        assert_eq!(
+            flat.nodes.len(),
+            flat.n_trees as usize * flat.max_tree_size as usize,
+            "nodes.len() should equal n_trees * max_tree_size"
+        );
+    }
+
+    /// Every slot beyond a tree's real BFS footprint must be a dummy leaf (test #15).
+    #[test]
+    fn padding_nodes_are_leaves() {
+        let (X, y) = make_data(150, 8, 15);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(10)
+            .with_seed(15);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&X.view(), &y.view());
+
+        let flat = FlatForest::from_forest(&forest, 8);
+        let n_trees = flat.n_trees as usize;
+        let max_tree_size = flat.max_tree_size as usize;
+
+        for tree_idx in 0..n_trees {
+            let offset = tree_idx * max_tree_size;
+            let tree_nodes = &flat.nodes[offset..offset + max_tree_size];
+            let real_count = count_bfs_nodes(tree_nodes);
+            for i in real_count..max_tree_size {
+                assert!(
+                    tree_nodes[i].left < 0,
+                    "tree {tree_idx}, slot {i} (beyond real size {real_count}): expected dummy leaf, got left={}",
+                    tree_nodes[i].left
+                );
+            }
+        }
+    }
+
+    /// Count reachable nodes from root via BFS using explicit child indices.
+    fn count_bfs_nodes(nodes: &[FlatNode]) -> usize {
+        use std::collections::VecDeque;
+        let mut queue = VecDeque::new();
+        queue.push_back(0usize);
+        let mut count = 0;
+        while let Some(idx) = queue.pop_front() {
+            if idx >= nodes.len() {
+                break;
+            }
+            count += 1;
+            let node = &nodes[idx];
+            if node.left >= 0 {
+                queue.push_back(node.left as usize);
+                queue.push_back(node.right as usize);
+            }
+        }
+        count
+    }
+}
+
 /// Recursively compute the depth of a node (0 = leaf, 1 = one split level, …).
 fn node_depth(node: &DecisionTreeNode) -> usize {
     if node.feature_index.is_none() {

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -3,6 +3,24 @@ use crate::tree::DecisionTreeNode;
 use ndarray::{Array1, ArrayView2};
 use std::collections::VecDeque;
 
+/// Forest metadata: dimensions shared by CPU and GPU inference.
+///
+/// NOTE: field order and types are significant for binary serde (e.g. postcard)
+/// and for direct GPU upload via bytemuck. Changing them requires a migration step
+/// for any data serialised with an earlier layout.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "gpu", derive(bytemuck::Pod, bytemuck::Zeroable))]
+pub struct ForestMeta {
+    pub n_trees: u32,
+    pub n_features: u32,
+    /// Nodes per tree (all trees are padded to this size).
+    pub max_tree_size: u32,
+    /// Maximum depth across all trees (used as a GPU traversal bound).
+    pub max_depth: u32,
+}
+
 /// A single node in a flat tree stored in BFS visit order.
 ///
 /// Internal nodes use `feature_index`, `threshold`, `left`, and `right`.
@@ -14,21 +32,27 @@ use std::collections::VecDeque;
 /// Field order: traversal-hot fields (`left`, `right`, `feature_index`,
 /// `threshold`) come first, the leaf-only field (`leaf_value`) last.
 /// `is_leaf` was removed — `left < 0` encodes leaf status without redundancy
-/// and without the 3-byte padding hole that `bool` caused before `threshold`.
+/// and without the 4-byte overhead that a separate boolean flag would require.
 ///
-/// NOTE: field order is significant for binary serde (e.g. postcard). If you
-/// need binary compatibility with data serialised before this change, a
-/// migration step is required.
-#[derive(Clone)]
+/// All floating-point values use `f32`, matching the GPU representation.
+/// CPU `predict_one` casts feature values to `f32` before comparison so that
+/// the CPU and GPU traversal paths are identical.
+///
+/// NOTE: field order and types are significant for binary serde (e.g. postcard)
+/// and for direct GPU upload via bytemuck. Changing them requires a migration step
+/// for any data serialised with an earlier layout.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "gpu", derive(bytemuck::Pod, bytemuck::Zeroable))]
 pub struct FlatNode {
     /// Index of the left child within the tree's node slice, or -1 for leaves.
     pub left: i32,
     /// Index of the right child within the tree's node slice, or -1 for leaves.
     pub right: i32,
     pub feature_index: u32,
-    pub threshold: f64,
-    pub leaf_value: f64,
+    pub threshold: f32,
+    pub leaf_value: f32,
 }
 
 impl FlatNode {
@@ -60,25 +84,32 @@ impl FlatNode {
 /// forest.fit(&X.view(), &y.view());
 ///
 /// let flat = FlatForest::from_forest(&forest, X.ncols());
-/// let predictions = flat.predict(&X.view()); // identical to forest.predict()
+/// let predictions = flat.predict(&X.view()); // comparable to forest.predict()
 /// ```
 ///
 /// Internally, each tree is stored in BFS order with explicit child indices so
 /// deep, sparse trees (common in practice) don't require exponential padding.
+///
+/// All thresholds and leaf values are stored as `f32`. CPU inference casts
+/// feature values to `f32` before comparison so that split decisions are
+/// identical to GPU inference. Results are accumulated in `f64` and returned
+/// as `f64` for API consistency with [`RandomForest::predict`].
 ///
 /// [`GpuForest::from_flat_forest`]: crate::gpu::GpuForest::from_flat_forest
 /// [`RandomForest`]: crate::RandomForest
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FlatForest {
-    /// Flat node array: length = `n_trees * max_tree_size`.
+    /// Flat node array: length = `meta.n_trees * meta.max_tree_size`.
     pub(crate) nodes: Vec<FlatNode>,
-    pub n_trees: usize,
-    pub n_features: usize,
-    /// Nodes per tree (all trees padded to this size).
-    pub max_tree_size: usize,
-    /// Maximum depth across all trees (used as a GPU traversal bound).
-    pub max_depth: usize,
+    pub meta: ForestMeta,
+}
+
+impl std::ops::Deref for FlatForest {
+    type Target = ForestMeta;
+    fn deref(&self) -> &ForestMeta {
+        &self.meta
+    }
 }
 
 impl FlatForest {
@@ -112,16 +143,20 @@ impl FlatForest {
 
         FlatForest {
             nodes,
-            n_trees,
-            n_features,
-            max_tree_size,
-            max_depth,
+            meta: ForestMeta {
+                n_trees: n_trees as u32,
+                n_features: n_features as u32,
+                max_tree_size: max_tree_size as u32,
+                max_depth: max_depth as u32,
+            },
         }
     }
 
     /// Run inference on a batch of samples.
     ///
-    /// Produces the same results as `RandomForest::predict` (mean of per-tree predictions).
+    /// Feature values are cast to `f32` internally so that split decisions are
+    /// identical to GPU inference. The per-tree leaf values (f32) are accumulated
+    /// in f64 and the final mean is returned as `Array1<f64>`.
     ///
     /// The loop order is outer=tree, inner=sample so that each tree's node array
     /// stays warm in L3 cache while all samples are processed against it, rather
@@ -130,7 +165,7 @@ impl FlatForest {
         let n_samples = X.nrows();
         let mut output = Array1::<f64>::zeros(n_samples);
 
-        for tree_idx in 0..self.n_trees {
+        for tree_idx in 0..self.meta.n_trees as usize {
             for sample in 0..n_samples {
                 let row = X.row(sample);
                 let features = row.as_slice().expect("feature row must be contiguous");
@@ -138,18 +173,19 @@ impl FlatForest {
             }
         }
 
-        output / self.n_trees as f64
+        output / self.meta.n_trees as f64
     }
 
     fn predict_one(&self, tree_idx: usize, features: &[f64]) -> f64 {
-        let offset = tree_idx * self.max_tree_size;
+        let offset = tree_idx * self.meta.max_tree_size as usize;
         let mut idx = 0usize;
-        for _ in 0..self.max_tree_size {
+        for _ in 0..self.meta.max_tree_size as usize {
             let node = &self.nodes[offset + idx];
             if node.left < 0 {
-                return node.leaf_value;
+                return node.leaf_value as f64;
             }
-            if features[node.feature_index as usize] < node.threshold {
+            // Cast feature to f32 to match GPU traversal exactly.
+            if (features[node.feature_index as usize] as f32) < node.threshold {
                 idx = node.left as usize;
             } else {
                 idx = node.right as usize;
@@ -157,7 +193,7 @@ impl FlatForest {
         }
         panic!(
             "predict_one: traversal exceeded max_tree_size ({}); tree may be malformed",
-            self.max_tree_size
+            self.meta.max_tree_size
         );
     }
 }
@@ -196,7 +232,7 @@ fn fill_bfs(root: &DecisionTreeNode, nodes: &mut [FlatNode]) {
                 right: -1,
                 feature_index: 0,
                 threshold: 0.0,
-                leaf_value: node.label.unwrap(),
+                leaf_value: node.label.unwrap() as f32,
             };
         } else {
             let left_idx = next_slot;
@@ -208,7 +244,7 @@ fn fill_bfs(root: &DecisionTreeNode, nodes: &mut [FlatNode]) {
                 left: left_idx as i32,
                 right: right_idx as i32,
                 feature_index: node.feature_index.unwrap() as u32,
-                threshold: node.feature_value.unwrap(),
+                threshold: node.feature_value.unwrap() as f32,
                 leaf_value: 0.0,
             };
 

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -11,7 +11,10 @@ use std::collections::VecDeque;
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "gpu", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    any(feature = "gpu", feature = "serde"),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 pub struct ForestMeta {
     pub n_trees: u32,
     pub n_features: u32,
@@ -40,7 +43,10 @@ pub struct ForestMeta {
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "gpu", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    any(feature = "gpu", feature = "serde"),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 pub struct FlatNode {
     /// Index of the left child within the tree's node slice, or -1 for leaves.
     pub left: i32,
@@ -97,6 +103,8 @@ impl FlatNode {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FlatForest {
     /// Flat node array: length = `meta.n_trees * meta.max_tree_size`.
+    // Serialized as raw bytes via bytemuck for speed (no per-field encoding).
+    #[cfg_attr(feature = "serde", serde(with = "flat_node_serde"))]
     pub(crate) nodes: Vec<FlatNode>,
     pub meta: ForestMeta,
 }
@@ -203,6 +211,54 @@ impl FlatForest {
             "predict_one: traversal exceeded max_depth={}",
             self.meta.max_depth
         );
+    }
+}
+
+#[cfg(feature = "serde")]
+mod flat_node_serde {
+    use super::FlatNode;
+    use serde::de::{Error, Visitor};
+    use serde::{Deserializer, Serializer};
+    use std::fmt;
+
+    pub fn serialize<S: Serializer>(nodes: &Vec<FlatNode>, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_bytes(bytemuck::cast_slice(nodes.as_slice()))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<FlatNode>, D::Error> {
+        d.deserialize_bytes(NodesVisitor)
+    }
+
+    struct NodesVisitor;
+
+    impl<'de> Visitor<'de> for NodesVisitor {
+        type Value = Vec<FlatNode>;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "raw bytes encoding a sequence of FlatNodes")
+        }
+
+        fn visit_bytes<E: Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+            nodes_from_bytes(v).map_err(E::custom)
+        }
+
+        fn visit_byte_buf<E: Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
+            self.visit_bytes(&v)
+        }
+    }
+
+    fn nodes_from_bytes(bytes: &[u8]) -> Result<Vec<FlatNode>, String> {
+        let node_size = std::mem::size_of::<FlatNode>();
+        if bytes.len() % node_size != 0 {
+            return Err(format!(
+                "expected a multiple of {node_size} bytes (FlatNode size), got {}",
+                bytes.len()
+            ));
+        }
+        let n = bytes.len() / node_size;
+        let mut nodes = vec![bytemuck::Zeroable::zeroed(); n];
+        bytemuck::cast_slice_mut::<FlatNode, u8>(&mut nodes).copy_from_slice(bytes);
+        Ok(nodes)
     }
 }
 

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -221,14 +221,7 @@ fn fill_bfs(root: &DecisionTreeNode, nodes: &mut [FlatNode]) {
     let mut next_slot = 1usize;
 
     while let Some((node, idx)) = queue.pop_front() {
-        if node.feature_index.is_none() {
-            nodes[idx] = FlatNode {
-                left: -1,
-                right: -1,
-                feature_index: 0,
-                value: node.label.unwrap() as f32,
-            };
-        } else {
+        if let Some(feature_index) = node.feature_index {
             let left_idx = next_slot;
             next_slot += 1;
             let right_idx = next_slot;
@@ -237,12 +230,19 @@ fn fill_bfs(root: &DecisionTreeNode, nodes: &mut [FlatNode]) {
             nodes[idx] = FlatNode {
                 left: left_idx as i32,
                 right: right_idx as i32,
-                feature_index: node.feature_index.unwrap() as u32,
+                feature_index: feature_index as u32,
                 value: node.feature_value.unwrap() as f32,
             };
 
             queue.push_back((node.left_child.as_ref().unwrap(), left_idx));
             queue.push_back((node.right_child.as_ref().unwrap(), right_idx));
+        } else {
+            nodes[idx] = FlatNode {
+                left: -1,
+                right: -1,
+                feature_index: 0,
+                value: node.label.unwrap() as f32,
+            };
         }
     }
 }

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -23,20 +23,16 @@ pub struct ForestMeta {
 
 /// A single node in a flat tree stored in BFS visit order.
 ///
-/// Internal nodes use `feature_index`, `threshold`, `left`, and `right`.
-/// Leaf nodes use `leaf_value`; `left` and `right` are -1.
+/// Internal nodes use `feature_index`, `value` (as threshold), `left`, and `right`.
+/// Leaf nodes use `value` (as the leaf prediction); `left` and `right` are -1.
+///
+/// `value` is a dual-purpose field: it holds the split threshold for internal
+/// nodes and the leaf prediction for leaf nodes. The two interpretations never
+/// overlap — `left < 0` unambiguously identifies leaves. This alias shrinks the
+/// struct from 20 → 16 bytes, fitting exactly 4 nodes per 64-byte cache line.
 ///
 /// Child indices are explicit offsets into the per-tree node slice, so trees
 /// of any shape can be stored without exponential padding.
-///
-/// Field order: traversal-hot fields (`left`, `right`, `feature_index`,
-/// `threshold`) come first, the leaf-only field (`leaf_value`) last.
-/// `is_leaf` was removed — `left < 0` encodes leaf status without redundancy
-/// and without the 4-byte overhead that a separate boolean flag would require.
-///
-/// All floating-point values use `f32`, matching the GPU representation.
-/// CPU `predict_one` casts feature values to `f32` before comparison so that
-/// the CPU and GPU traversal paths are identical.
 ///
 /// NOTE: field order and types are significant for binary serde (e.g. postcard)
 /// and for direct GPU upload via bytemuck. Changing them requires a migration step
@@ -51,19 +47,13 @@ pub struct FlatNode {
     /// Index of the right child within the tree's node slice, or -1 for leaves.
     pub right: i32,
     pub feature_index: u32,
-    pub threshold: f32,
-    pub leaf_value: f32,
+    /// Split threshold for internal nodes; leaf prediction for leaf nodes.
+    pub value: f32,
 }
 
 impl FlatNode {
     fn dummy_leaf() -> Self {
-        FlatNode {
-            left: -1,
-            right: -1,
-            feature_index: 0,
-            threshold: 0.0,
-            leaf_value: 0.0,
-        }
+        FlatNode { left: -1, right: -1, feature_index: 0, value: 0.0 }
     }
 }
 
@@ -182,10 +172,10 @@ impl FlatForest {
         for _ in 0..self.meta.max_tree_size as usize {
             let node = &self.nodes[offset + idx];
             if node.left < 0 {
-                return node.leaf_value as f64;
+                return node.value as f64;
             }
             // Cast feature to f32 to match GPU traversal exactly.
-            if (features[node.feature_index as usize] as f32) < node.threshold {
+            if (features[node.feature_index as usize] as f32) < node.value {
                 idx = node.left as usize;
             } else {
                 idx = node.right as usize;
@@ -231,8 +221,7 @@ fn fill_bfs(root: &DecisionTreeNode, nodes: &mut [FlatNode]) {
                 left: -1,
                 right: -1,
                 feature_index: 0,
-                threshold: 0.0,
-                leaf_value: node.label.unwrap() as f32,
+                value: node.label.unwrap() as f32,
             };
         } else {
             let left_idx = next_slot;
@@ -244,8 +233,7 @@ fn fill_bfs(root: &DecisionTreeNode, nodes: &mut [FlatNode]) {
                 left: left_idx as i32,
                 right: right_idx as i32,
                 feature_index: node.feature_index.unwrap() as u32,
-                threshold: node.feature_value.unwrap() as f32,
-                leaf_value: 0.0,
+                value: node.feature_value.unwrap() as f32,
             };
 
             queue.push_back((node.left_child.as_ref().unwrap(), left_idx));

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -53,7 +53,12 @@ pub struct FlatNode {
 
 impl FlatNode {
     fn dummy_leaf() -> Self {
-        FlatNode { left: -1, right: -1, feature_index: 0, value: 0.0 }
+        FlatNode {
+            left: -1,
+            right: -1,
+            feature_index: 0,
+            value: 0.0,
+        }
     }
 }
 

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -204,9 +204,17 @@ mod tests {
     use rand::SeedableRng;
     use rand::rngs::StdRng;
 
-    fn make_data(n_samples: usize, n_features: usize, seed: u64) -> (Array2<f64>, ndarray::Array1<f64>) {
+    fn make_data(
+        n_samples: usize,
+        n_features: usize,
+        seed: u64,
+    ) -> (Array2<f64>, ndarray::Array1<f64>) {
         let mut rng = StdRng::seed_from_u64(seed);
-        let X = Array2::random_using((n_samples, n_features), Uniform::new(0.0, 1.0).unwrap(), &mut rng);
+        let X = Array2::random_using(
+            (n_samples, n_features),
+            Uniform::new(0.0, 1.0).unwrap(),
+            &mut rng,
+        );
         let y = X.column(0).to_owned();
         (X, y)
     }
@@ -252,6 +260,75 @@ mod tests {
                     tree_nodes[i].left < 0,
                     "tree {tree_idx}, slot {i} (beyond real size {real_count}): expected dummy leaf, got left={}",
                     tree_nodes[i].left
+                );
+            }
+        }
+    }
+
+    /// `max_tree_size` must equal the actual maximum node count, not the BFS positional
+    /// formula `2^(max_depth+1) - 1` (test #3). For unconstrained trees deep enough that
+    /// the positional layout would differ, the two values must diverge.
+    #[test]
+    fn max_tree_size_is_actual_count_not_bfs_formula() {
+        let (X, y) = make_data(150, 6, 42);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(10)
+            .with_seed(42);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&X.view(), &y.view());
+
+        let flat = FlatForest::from_forest(&forest, 6);
+
+        // Independent recomputation of max node count using the private helper.
+        let expected_max = forest
+            .trees()
+            .iter()
+            .map(|t| count_nodes(t.root()))
+            .max()
+            .unwrap();
+        assert_eq!(
+            flat.max_tree_size as usize, expected_max,
+            "max_tree_size should equal the actual max node count across trees"
+        );
+
+        // For trees with max_depth >= 4, the positional BFS layout would require
+        // at least 2^5 - 1 = 31 nodes, whereas typical trees with the same depth
+        // but sparse structure will have far fewer. Assert we use the compact count.
+        let bfs_formula = (1usize << (flat.max_depth as usize + 1)).saturating_sub(1);
+        if flat.max_depth >= 4 {
+            assert!(
+                (flat.max_tree_size as usize) < bfs_formula,
+                "max_tree_size ({}) should be less than BFS formula ({}) for depth-{} trees",
+                flat.max_tree_size,
+                bfs_formula,
+                flat.max_depth
+            );
+        }
+    }
+
+    /// Every padding node beyond a tree's real BFS footprint must have `value == 0.0` (test #5).
+    /// This verifies that `FlatNode::dummy_leaf()` initialises `value` to zero, so padding
+    /// slots cannot accidentally contribute non-zero predictions if the loop bound is wrong.
+    #[test]
+    fn dummy_leaf_value_is_zero() {
+        let (X, y) = make_data(150, 8, 50);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(10)
+            .with_seed(50);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&X.view(), &y.view());
+
+        let flat = FlatForest::from_forest(&forest, 8);
+        let max_tree_size = flat.max_tree_size as usize;
+
+        for tree_idx in 0..flat.n_trees as usize {
+            let offset = tree_idx * max_tree_size;
+            let tree_nodes = &flat.nodes[offset..offset + max_tree_size];
+            let real_count = count_bfs_nodes(tree_nodes);
+            for i in real_count..max_tree_size {
+                assert_eq!(
+                    tree_nodes[i].value, 0.0,
+                    "tree {tree_idx}, padding slot {i}: expected value=0.0"
                 );
             }
         }

--- a/src/flat_forest.rs
+++ b/src/flat_forest.rs
@@ -175,21 +175,20 @@ impl FlatForest {
     fn predict_one(&self, tree_idx: usize, features: &[f32]) -> f64 {
         let offset = tree_idx * self.meta.max_tree_size as usize;
         let mut idx = 0usize;
-        for _ in 0..self.meta.max_tree_size as usize {
+        for _ in 0..=self.meta.max_depth as usize {
             let node = &self.nodes[offset + idx];
             if node.left < 0 {
                 return node.value as f64;
             }
-            // Cast feature to f32 to match GPU traversal exactly.
-            if (features[node.feature_index as usize] as f32) < node.value {
+            if features[node.feature_index as usize] < node.value {
                 idx = node.left as usize;
             } else {
                 idx = node.right as usize;
             }
         }
         panic!(
-            "predict_one: traversal exceeded max_tree_size ({}); tree may be malformed",
-            self.meta.max_tree_size
+            "predict_one: traversal exceeded max_depth ({}); tree may be malformed",
+            self.meta.max_depth
         );
     }
 }

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -9,6 +9,21 @@ use rand::rngs::StdRng;
 use rayon::ThreadPoolBuilder;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
+/// Configuration for a [`RandomForest`].
+///
+/// Use the builder methods to customise the forest. Most users only need to
+/// change `n_estimators` and `seed`; all other parameters have sensible defaults.
+///
+/// ```rust
+/// use biosphere::{RandomForestParameters, MaxFeatures};
+///
+/// let params = RandomForestParameters::default()
+///     .with_n_estimators(200)
+///     .with_seed(42)
+///     .with_max_depth(Some(10))
+///     .with_max_features(MaxFeatures::Sqrt)
+///     .with_n_jobs(Some(-1)); // use all CPU cores for training
+/// ```
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RandomForestParameters {
@@ -97,6 +112,28 @@ impl RandomForestParameters {
     }
 }
 
+/// A random forest ensemble for regression or binary classification.
+///
+/// Trains many [`DecisionTree`]s on bootstrap samples of your data and averages
+/// their predictions. More trees reduce variance at diminishing returns; 100–500
+/// is usually enough.
+///
+/// ```rust
+/// use biosphere::{RandomForest, RandomForestParameters};
+/// use ndarray::array;
+///
+/// let X = array![[0.0, 1.0], [1.0, 0.0]];
+/// let y = array![0.0, 1.0];
+///
+/// let mut forest = RandomForest::new(RandomForestParameters::default());
+/// forest.fit(&X.view(), &y.view());
+///
+/// let predictions = forest.predict(&X.view()); // Array1<f64>, one value per row
+/// ```
+///
+/// For GPU inference, convert to a [`FlatForest`] first.
+///
+/// [`FlatForest`]: crate::FlatForest
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RandomForest {

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -274,30 +274,3 @@ impl RandomForest {
         oob_predictions * oob_n_estimators.mapv(|x| 1. / x as f64)
     }
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use crate::testing::load_iris;
-//     use ndarray::s;
-
-//     #[test]
-//     fn test_random_forest_predict() {
-//         let data = load_iris();
-//         let X = data.slice(s![0..100, 0..4]);
-//         let y = data.slice(s![0..100, 4]);
-
-//         let random_forest_parameters = RandomForestParameters::default();
-//         let forest = RandomForest::new(&X, &y, random_forest_parameters);
-
-//         let predictions = forest.predict();
-//         let mse = (&predictions - &y).mapv(|x| x * x).sum();
-//         assert!(
-//             mse < 0.1,
-//             "mse {} \ny={:?}\npredictions={:?}",
-//             mse,
-//             y,
-//             predictions
-//         );
-//     }
-// }

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -6,7 +6,6 @@ use ndarray::{Array1, ArrayView1, ArrayView2};
 use rand::Rng;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-use rayon::ThreadPoolBuilder;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 /// Configuration for a [`RandomForest`].
@@ -141,6 +140,19 @@ pub struct RandomForest {
     trees: Vec<DecisionTree>,
 }
 
+fn build_thread_pool(n_jobs: Option<i32>) -> rayon::ThreadPool {
+    let mut builder = rayon::ThreadPoolBuilder::new();
+    let n_threads = match n_jobs {
+        Some(n) if n >= 1 => Some(n as usize),
+        Some(_) => None, // -1 = all cores
+        None => Some(1),
+    };
+    if let Some(n) = n_threads {
+        builder = builder.num_threads(n);
+    }
+    builder.build().expect("failed to build rayon thread pool")
+}
+
 impl Default for RandomForest {
     fn default() -> Self {
         RandomForest::new(RandomForestParameters::default())
@@ -161,34 +173,18 @@ impl RandomForest {
 
     pub fn predict(&self, X: &ArrayView2<f64>) -> Array1<f64> {
         let mut predictions = Array1::<f64>::zeros(X.nrows());
+        let mut scratch = Array1::<f64>::zeros(X.nrows());
 
         for tree in &self.trees {
-            predictions = predictions + tree.predict(X);
+            tree.predict_into(X, &mut scratch);
+            predictions += &scratch;
         }
 
         predictions / self.trees.len() as f64
     }
 
     pub fn fit(&mut self, X: &ArrayView2<f64>, y: &ArrayView1<f64>) {
-        let mut thread_pool_builder = ThreadPoolBuilder::new();
-
-        // If n_jobs = 1 or None, use a single process. If n_jobs = -1, use all processes.
-        let n_jobs_usize = match self.random_forest_parameters.n_jobs {
-            Some(n_jobs) => {
-                if n_jobs >= 1 {
-                    Some(n_jobs as usize)
-                } else {
-                    None
-                }
-            }
-            None => Some(1),
-        };
-
-        if let Some(n_jobs) = n_jobs_usize {
-            thread_pool_builder = thread_pool_builder.num_threads(n_jobs);
-        }
-
-        let thread_pool = thread_pool_builder.build().unwrap();
+        let thread_pool = build_thread_pool(self.random_forest_parameters.n_jobs);
 
         let indices: Vec<usize> = (0..X.ncols()).collect();
         let indices: Vec<Vec<usize>> = thread_pool.install(|| {
@@ -234,26 +230,14 @@ impl RandomForest {
         })
     }
 
+    /// Fit the forest and return out-of-bag predictions for each training sample.
+    ///
+    /// Each element of the returned array is the average prediction of the trees
+    /// for which that sample was out-of-bag. Samples that were in-bag for every
+    /// estimator (i.e. never left out during bootstrap sampling) will have
+    /// `f64::NAN` as their OOB prediction.
     pub fn fit_predict_oob(&mut self, X: &ArrayView2<f64>, y: &ArrayView1<f64>) -> Array1<f64> {
-        let mut thread_pool_builder = ThreadPoolBuilder::new();
-
-        // If n_jobs = 1 or None, use a single process. If n_jobs = -1, use all processes.
-        let n_jobs_usize = match self.random_forest_parameters.n_jobs {
-            Some(n_jobs) => {
-                if n_jobs >= 1 {
-                    Some(n_jobs as usize)
-                } else {
-                    None
-                }
-            }
-            None => Some(1),
-        };
-
-        if let Some(n_jobs) = n_jobs_usize {
-            thread_pool_builder = thread_pool_builder.num_threads(n_jobs);
-        }
-
-        let thread_pool = thread_pool_builder.build().unwrap();
+        let thread_pool = build_thread_pool(self.random_forest_parameters.n_jobs);
 
         let indices: Vec<usize> = (0..X.ncols()).collect();
 
@@ -280,7 +264,7 @@ impl RandomForest {
                     let mut tree = DecisionTree::new(
                         tree_parameters
                             .clone()
-                            .with_random_state(rng.random::<u64>()),
+                            .with_random_state(seed),
                     );
 
                     let weights = sample_weights(X.nrows(), &mut rng);
@@ -312,6 +296,10 @@ impl RandomForest {
             }
         }
 
-        oob_predictions * oob_n_estimators.mapv(|x| 1. / x as f64)
+        Array1::from_iter(
+            oob_predictions.iter().zip(oob_n_estimators.iter()).map(|(&pred, &n)| {
+                if n == 0 { f64::NAN } else { pred / n as f64 }
+            })
+        )
     }
 }

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -10,6 +10,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon::ThreadPoolBuilder;
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RandomForestParameters {
     decision_tree_parameters: DecisionTreeParameters,
     n_estimators: usize,
@@ -96,6 +97,8 @@ impl RandomForestParameters {
     }
 }
 
+#[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RandomForest {
     random_forest_parameters: RandomForestParameters,
     trees: Vec<DecisionTree>,

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -3,11 +3,11 @@ use crate::utils::{
     argsort, oob_samples_from_weights, sample_indices_from_weights, sample_weights,
 };
 use ndarray::{Array1, ArrayView1, ArrayView2};
-use rand::rngs::StdRng;
 use rand::Rng;
 use rand::SeedableRng;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rand::rngs::StdRng;
 use rayon::ThreadPoolBuilder;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -261,11 +261,8 @@ impl RandomForest {
                 .into_par_iter()
                 .map(move |seed| {
                     let mut rng = StdRng::seed_from_u64(seed);
-                    let mut tree = DecisionTree::new(
-                        tree_parameters
-                            .clone()
-                            .with_random_state(seed),
-                    );
+                    let mut tree =
+                        DecisionTree::new(tree_parameters.clone().with_random_state(seed));
 
                     let weights = sample_weights(X.nrows(), &mut rng);
                     let mut samples = sample_indices_from_weights(&weights, &indices);
@@ -297,9 +294,14 @@ impl RandomForest {
         }
 
         Array1::from_iter(
-            oob_predictions.iter().zip(oob_n_estimators.iter()).map(|(&pred, &n)| {
-                if n == 0 { f64::NAN } else { pred / n as f64 }
-            })
+            oob_predictions
+                .iter()
+                .zip(oob_n_estimators.iter())
+                .map(
+                    |(&pred, &n)| {
+                        if n == 0 { f64::NAN } else { pred / n as f64 }
+                    },
+                ),
         )
     }
 }

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -118,6 +118,10 @@ impl RandomForest {
         }
     }
 
+    pub(crate) fn trees(&self) -> &[DecisionTree] {
+        &self.trees
+    }
+
     pub fn predict(&self, X: &ArrayView2<f64>) -> Array1<f64> {
         let mut predictions = Array1::<f64>::zeros(X.nrows());
 

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -183,6 +183,12 @@ impl RandomForest {
         predictions / self.trees.len() as f64
     }
 
+    /// Fit the forest on training data.
+    ///
+    /// **Reproducibility note (v0.5):** Each tree's feature-selection seed is now derived
+    /// directly from its bootstrap seed rather than from a secondary RNG draw. Forests
+    /// trained with the same seed as v0.4.x will produce different trees starting from
+    /// v0.5.0.
     pub fn fit(&mut self, X: &ArrayView2<f64>, y: &ArrayView1<f64>) {
         let thread_pool = build_thread_pool(self.random_forest_parameters.n_jobs);
 
@@ -236,6 +242,11 @@ impl RandomForest {
     /// for which that sample was out-of-bag. Samples that were in-bag for every
     /// estimator (i.e. never left out during bootstrap sampling) will have
     /// `f64::NAN` as their OOB prediction.
+    ///
+    /// **Reproducibility note (v0.5):** Each tree's feature-selection seed is now derived
+    /// directly from its bootstrap seed rather than from a secondary RNG draw. Forests
+    /// trained with the same seed as v0.4.x will produce different trees starting from
+    /// v0.5.0.
     pub fn fit_predict_oob(&mut self, X: &ArrayView2<f64>, y: &ArrayView1<f64>) -> Array1<f64> {
         let thread_pool = build_thread_pool(self.random_forest_parameters.n_jobs);
 

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,0 +1,76 @@
+//! GPU-accelerated inference for trained random forests.
+//!
+//! Enabled with the `gpu` feature flag. Uses [wgpu] compute shaders (Vulkan,
+//! Metal, DX12, WebGPU) with no platform-specific code.
+//!
+//! # Quick start
+//!
+//! ```rust,no_run
+//! use biosphere::{FlatForest, RandomForest, RandomForestParameters};
+//! use biosphere::gpu::GpuForest;
+//! use ndarray::Array2;
+//!
+//! // 1. Train a forest as usual.
+//! let X: Array2<f64> = /* ... your training data ... */
+//! # Array2::zeros((1, 1));
+//! let y = /* ... your labels ... */
+//! # ndarray::Array1::zeros(1);
+//! let mut forest = RandomForest::new(RandomForestParameters::default());
+//! forest.fit(&X.view(), &y.view());
+//!
+//! // 2. Convert to a flat BFS representation (works on CPU too).
+//! let n_features = X.ncols();
+//! let flat = FlatForest::from_forest(&forest, n_features);
+//!
+//! // 3. Upload to the GPU.
+//! let gpu_forest = GpuForest::from_flat_forest(&flat);
+//!
+//! // 4. Run inference. Features must be f32, row-major (n_samples × n_features).
+//! let test_X: Array2<f64> = /* ... your test data ... */
+//! # Array2::zeros((1, 1));
+//! let n_samples = test_X.nrows();
+//! let features_f32: Vec<f32> = test_X.iter().map(|&v| v as f32).collect();
+//! let predictions: Vec<f32> = gpu_forest.predict(&features_f32, n_samples);
+//! ```
+//!
+//! # Data flow
+//!
+//! ```text
+//! RandomForest  ──from_forest──►  FlatForest (f64, CPU)
+//!                                      │
+//!                              from_flat_forest
+//!                                      │
+//!                                      ▼
+//!                               GpuForest (f32, GPU)
+//!                                      │
+//!                                  predict()
+//!                                      │
+//!                        ┌────────────────────────┐
+//!                        │ traverse.wgsl          │
+//!                        │  one thread per        │
+//!                        │  (sample, tree) pair   │
+//!                        └──────────┬─────────────┘
+//!                                   │ per-tree predictions
+//!                        ┌──────────▼─────────────┐
+//!                        │ reduce.wgsl             │
+//!                        │  mean across trees      │
+//!                        └──────────┬─────────────┘
+//!                                   │
+//!                              Vec<f32> output
+//! ```
+//!
+//! # Precision
+//!
+//! [`FlatForest`] stores thresholds and leaf values as `f64` and produces
+//! results identical to [`RandomForest::predict`].
+//!
+//! [`GpuForest`] converts those values to `f32` on upload. For samples whose
+//! feature value falls very close to a split threshold the GPU prediction may
+//! differ slightly from the CPU prediction. In practice the difference is
+//! within normal f32 rounding error (~1 × 10⁻⁷ relative).
+//!
+//! [`FlatForest`]: crate::FlatForest
+//! [`RandomForest::predict`]: crate::RandomForest::predict
+
+mod pipeline;
+pub use pipeline::GpuForest;

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -58,6 +58,47 @@
 //!                           Array1<f32> output
 //! ```
 //!
+//! # Pipelining — overlapping GPU work across batches
+//!
+//! [`GpuForest::predict`] submits work and blocks until results are ready.
+//! For higher throughput, use [`GpuForest::predict_submit`] to start GPU work
+//! immediately and [`PredictHandle::collect`] to retrieve results later.
+//! Submitting from two forked handles before collecting either lets the GPU
+//! run both jobs concurrently.
+//!
+//! ```rust,no_run
+//! use biosphere::{FlatForest, RandomForest, RandomForestParameters};
+//! use biosphere::gpu::GpuForest;
+//! use ndarray::Array2;
+//!
+//! # let flat = FlatForest::from_forest(
+//! #     &{ let mut f = RandomForest::new(RandomForestParameters::default());
+//! #        f.fit(&Array2::<f64>::zeros((2,2)).view(), &ndarray::Array1::zeros(2).view()); f },
+//! #     2);
+//! // Two handles sharing compiled pipelines and uploaded node data.
+//! let forest_a = GpuForest::from_flat_forest(&flat, 1024);
+//! let forest_b = forest_a.fork(1024);
+//!
+//! let batch_a: Array2<f32> = /* ... first batch ... */
+//! # Array2::zeros((1, 2));
+//! let batch_b: Array2<f32> = /* ... second batch ... */
+//! # Array2::zeros((1, 2));
+//!
+//! // Submit both without waiting — the GPU can work on them concurrently.
+//! let handle_a = forest_a.predict_submit(&batch_a.view()).unwrap();
+//! let handle_b = forest_b.predict_submit(&batch_b.view()).unwrap();
+//!
+//! // Collect in any order; each blocks only until its own submission is done.
+//! let preds_a = handle_a.collect();
+//! let preds_b = handle_b.collect();
+//! ```
+//!
+//! Each [`GpuForest`] instance enforces a single-outstanding-handle constraint:
+//! calling [`predict_submit`] again before collecting the previous handle panics.
+//! Use [`GpuForest::fork`] to get independent handles.
+//!
+//! [`predict_submit`]: GpuForest::predict_submit
+//!
 //! # Precision
 //!
 //! [`FlatForest`] stores thresholds and leaf values as `f32`. CPU inference

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -36,7 +36,7 @@
 //! # Data flow
 //!
 //! ```text
-//! RandomForest  ──from_forest──►  FlatForest (f64, CPU)
+//! RandomForest  ──from_forest──►  FlatForest (f32 nodes, CPU)
 //!                                      │
 //!                              from_flat_forest
 //!                                      │
@@ -61,13 +61,17 @@
 //!
 //! # Precision
 //!
-//! [`FlatForest`] stores thresholds and leaf values as `f64` and produces
-//! results identical to [`RandomForest::predict`].
-//!
-//! [`GpuForest`] converts those values to `f32` on upload. For samples whose
-//! feature value falls very close to a split threshold the GPU prediction may
-//! differ slightly from the CPU prediction. In practice the difference is
+//! [`FlatForest`] stores thresholds and leaf values as `f32`. CPU inference
+//! casts feature values to `f32` before comparison so that split decisions are
+//! identical to GPU inference. Results may differ slightly from
+//! [`RandomForest::predict`] (which uses `f64` throughout); the difference is
 //! within normal f32 rounding error (~1 × 10⁻⁷ relative).
+//!
+//! Because both [`FlatForest::predict`] and [`GpuForest::predict`] use `f32`
+//! comparisons, their predictions agree very closely. The only remaining
+//! difference is that `FlatForest` accumulates leaf values in `f64` while the
+//! GPU shader accumulates in `f32`; this contributes at most ~n_trees × 10⁻⁷
+//! additional error.
 //!
 //! [`FlatForest`]: crate::FlatForest
 //! [`RandomForest::predict`]: crate::RandomForest::predict

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -22,8 +22,8 @@
 //! let n_features = X.ncols();
 //! let flat = FlatForest::from_forest(&forest, n_features);
 //!
-//! // 3. Upload to the GPU.
-//! let gpu_forest = GpuForest::from_flat_forest(&flat);
+//! // 3. Upload to the GPU, reserving capacity for up to 1024 samples per call.
+//! let gpu_forest = GpuForest::from_flat_forest(&flat, 1024);
 //!
 //! // 4. Run inference. Features must be f32, row-major (n_samples × n_features).
 //! let test_X: Array2<f64> = /* ... your test data ... */

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -29,7 +29,7 @@
 //! let test_X: Array2<f64> = /* ... your test data ... */
 //! # Array2::zeros((1, 1));
 //! let test_X_f32 = test_X.mapv(|v| v as f32);
-//! let predictions: ndarray::Array1<f32> = gpu_forest.predict(&test_X_f32.view());
+//! let predictions: ndarray::Array1<f32> = gpu_forest.predict(&test_X_f32.view()).unwrap();
 //! ```
 //!
 //! # Multiple forests — shared device
@@ -112,12 +112,12 @@
 //! # Array2::zeros((1, 2));
 //!
 //! // Submit both without waiting — the GPU can work on them concurrently.
-//! let handle_a = forest_a.predict_submit(&batch_a.view()).unwrap();
-//! let handle_b = forest_b.predict_submit(&batch_b.view()).unwrap();
+//! let handle_a = forest_a.predict_submit(&batch_a.view()).unwrap().unwrap();
+//! let handle_b = forest_b.predict_submit(&batch_b.view()).unwrap().unwrap();
 //!
 //! // Collect in any order; each blocks only until its own submission is done.
-//! let preds_a = handle_a.collect();
-//! let preds_b = handle_b.collect();
+//! let preds_a = handle_a.collect().unwrap();
+//! let preds_b = handle_b.collect().unwrap();
 //! ```
 //!
 //! Each [`GpuForest`] instance enforces a single-outstanding-handle constraint:
@@ -144,4 +144,4 @@
 //! [`RandomForest::predict`]: crate::RandomForest::predict
 
 mod pipeline;
-pub use pipeline::{GpuContext, GpuForest, GpuInitError, PredictHandle};
+pub use pipeline::{GpuContext, GpuForest, GpuInferenceError, GpuInitError, PredictHandle};

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -25,12 +25,11 @@
 //! // 3. Upload to the GPU, reserving capacity for up to 1024 samples per call.
 //! let gpu_forest = GpuForest::from_flat_forest(&flat, 1024);
 //!
-//! // 4. Run inference. Features must be f32, row-major (n_samples × n_features).
+//! // 4. Run inference. Features must be f32 (cast from f64 if needed).
 //! let test_X: Array2<f64> = /* ... your test data ... */
 //! # Array2::zeros((1, 1));
-//! let n_samples = test_X.nrows();
-//! let features_f32: Vec<f32> = test_X.iter().map(|&v| v as f32).collect();
-//! let predictions: Vec<f32> = gpu_forest.predict(&features_f32, n_samples);
+//! let test_X_f32 = test_X.mapv(|v| v as f32);
+//! let predictions: ndarray::Array1<f32> = gpu_forest.predict(&test_X_f32.view());
 //! ```
 //!
 //! # Data flow
@@ -56,7 +55,7 @@
 //!                        │  mean across trees      │
 //!                        └──────────┬─────────────┘
 //!                                   │
-//!                              Vec<f32> output
+//!                           Array1<f32> output
 //! ```
 //!
 //! # Precision

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -3,7 +3,7 @@
 //! Enabled with the `gpu` feature flag. Uses [wgpu] compute shaders (Vulkan,
 //! Metal, DX12, WebGPU) with no platform-specific code.
 //!
-//! # Quick start
+//! # Quick start — single forest
 //!
 //! ```rust,no_run
 //! use biosphere::{FlatForest, RandomForest, RandomForestParameters};
@@ -18,7 +18,7 @@
 //! let mut forest = RandomForest::new(RandomForestParameters::default());
 //! forest.fit(&X.view(), &y.view());
 //!
-//! // 2. Convert to a flat BFS representation (works on CPU too).
+//! // 2. Convert to a flat representation (works on CPU too).
 //! let n_features = X.ncols();
 //! let flat = FlatForest::from_forest(&forest, n_features);
 //!
@@ -32,12 +32,39 @@
 //! let predictions: ndarray::Array1<f32> = gpu_forest.predict(&test_X_f32.view());
 //! ```
 //!
+//! # Multiple forests — shared device
+//!
+//! When serving several forests, initialise a [`GpuContext`] once and pass it
+//! to each [`GpuForest::with_context`] call. This reuses the GPU device and
+//! compiled compute pipelines, avoiding redundant initialisation overhead.
+//!
+//! ```rust,no_run
+//! use biosphere::{FlatForest, RandomForest, RandomForestParameters};
+//! use biosphere::gpu::{GpuContext, GpuForest};
+//! use ndarray::Array2;
+//!
+//! # let make_flat = |seed| {
+//! #     let mut f = RandomForest::new(RandomForestParameters::default().with_seed(seed));
+//! #     f.fit(&Array2::<f64>::zeros((2, 1)).view(), &ndarray::Array1::zeros(2).view());
+//! #     FlatForest::from_forest(&f, 1)
+//! # };
+//! # let flat_a = make_flat(1);
+//! # let flat_b = make_flat(2);
+//! // Initialise device + compile shaders once.
+//! let ctx = GpuContext::new().unwrap();
+//!
+//! // Each forest gets its own node/meta buffers and inference buffers,
+//! // but shares the device, queue, and pipelines.
+//! let forest_a = GpuForest::with_context(ctx.clone(), &flat_a, 1024);
+//! let forest_b = GpuForest::with_context(ctx.clone(), &flat_b, 2048);
+//! ```
+//!
 //! # Data flow
 //!
 //! ```text
 //! RandomForest  ──from_forest──►  FlatForest (f32 nodes, CPU)
 //!                                      │
-//!                              from_flat_forest
+//!                         from_flat_forest / with_context
 //!                                      │
 //!                                      ▼
 //!                               GpuForest (f32, GPU)
@@ -117,4 +144,4 @@
 //! [`RandomForest::predict`]: crate::RandomForest::predict
 
 mod pipeline;
-pub use pipeline::{GpuForest, GpuInitError, PredictHandle};
+pub use pipeline::{GpuContext, GpuForest, GpuInitError, PredictHandle};

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -23,7 +23,7 @@
 //! let flat = FlatForest::from_forest(&forest, n_features);
 //!
 //! // 3. Upload to the GPU, reserving capacity for up to 1024 samples per call.
-//! let gpu_forest = GpuForest::from_flat_forest(&flat, 1024);
+//! let gpu_forest = GpuForest::from_flat_forest(&flat, 1024).unwrap();
 //!
 //! // 4. Run inference. Features must be f32 (cast from f64 if needed).
 //! let test_X: Array2<f64> = /* ... your test data ... */
@@ -76,7 +76,7 @@
 //! #        f.fit(&Array2::<f64>::zeros((2,2)).view(), &ndarray::Array1::zeros(2).view()); f },
 //! #     2);
 //! // Two handles sharing compiled pipelines and uploaded node data.
-//! let forest_a = GpuForest::from_flat_forest(&flat, 1024);
+//! let forest_a = GpuForest::from_flat_forest(&flat, 1024).unwrap();
 //! let forest_b = forest_a.fork(1024);
 //!
 //! let batch_a: Array2<f32> = /* ... first batch ... */
@@ -117,4 +117,4 @@
 //! [`RandomForest::predict`]: crate::RandomForest::predict
 
 mod pipeline;
-pub use pipeline::{GpuForest, PredictHandle};
+pub use pipeline::{GpuForest, GpuInitError, PredictHandle};

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -73,4 +73,4 @@
 //! [`RandomForest::predict`]: crate::RandomForest::predict
 
 mod pipeline;
-pub use pipeline::GpuForest;
+pub use pipeline::{GpuForest, PredictHandle};

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -1,6 +1,8 @@
 use crate::flat_forest::{FlatForest, FlatNode, ForestMeta};
 use ndarray::{Array1, ArrayView2};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 use wgpu::util::DeviceExt;
 
 /// GPU state shared across all [`GpuForest`] instances forked from the same forest.
@@ -46,10 +48,14 @@ impl<'forest> PredictHandle<'forest> {
     /// Block until the GPU finishes this submission and return the predictions.
     ///
     /// One `f32` per sample, in the same order as the input to [`GpuForest::predict_submit`].
+    ///
+    /// Panics if the GPU does not complete within the timeout configured via
+    /// [`GpuForest::with_collect_timeout`] (default: 10 seconds).
     pub fn collect(self) -> Array1<f32> {
         let device = &self.forest.shared.device;
+        let timeout = self.forest.collect_timeout;
 
-        if self.forest.shared.uma {
+        let result = if self.forest.shared.uma {
             // UMA path: output_buffer has MAP_READ usage, so we read directly
             // without a staging copy. The poll also waits for the GPU submission.
             let slice = self.forest.output_buffer.slice(..self.output_bytes);
@@ -59,9 +65,9 @@ impl<'forest> PredictHandle<'forest> {
             device
                 .poll(wgpu::PollType::Wait {
                     submission_index: Some(self.submit_idx),
-                    timeout: Some(std::time::Duration::from_secs(10)),
+                    timeout: Some(timeout),
                 })
-                .expect("GPU poll failed");
+                .expect("GPU timed out during inference; consider increasing the timeout with GpuForest::with_collect_timeout");
             let data = slice.get_mapped_range();
             let result = Array1::from(bytemuck::cast_slice::<u8, f32>(&data).to_vec());
             drop(data);
@@ -78,15 +84,19 @@ impl<'forest> PredictHandle<'forest> {
             device
                 .poll(wgpu::PollType::Wait {
                     submission_index: Some(self.submit_idx),
-                    timeout: Some(std::time::Duration::from_secs(10)),
+                    timeout: Some(timeout),
                 })
-                .expect("GPU poll failed");
+                .expect("GPU timed out during inference; consider increasing the timeout with GpuForest::with_collect_timeout");
             let data = buffer_slice.get_mapped_range();
             let result = Array1::from(bytemuck::cast_slice::<u8, f32>(&data).to_vec());
             drop(data);
             staging.unmap();
             result
-        }
+        };
+
+        // Release the busy flag so predict_submit can be called again.
+        self.forest.busy.store(false, Ordering::Release);
+        result
     }
 }
 
@@ -118,6 +128,15 @@ pub struct GpuForest {
     /// Discrete: `COPY_DST | MAP_READ`, sized for `max_samples * 4` bytes.
     staging_buffer: Option<wgpu::Buffer>,
     max_samples: usize,
+    /// Maximum time [`PredictHandle::collect`] will wait for the GPU.
+    /// Default: 10 seconds.
+    collect_timeout: Duration,
+    /// Set to `true` while a [`PredictHandle`] is outstanding. Guards against
+    /// calling [`predict_submit`] again before the previous handle is collected,
+    /// which would overwrite the feature buffer while the GPU may still read it.
+    ///
+    /// [`predict_submit`]: GpuForest::predict_submit
+    busy: AtomicBool,
 }
 
 impl GpuForest {
@@ -337,6 +356,8 @@ impl GpuForest {
             output_buffer,
             staging_buffer,
             max_samples,
+            collect_timeout: Duration::from_secs(10),
+            busy: AtomicBool::new(false),
         }
     }
 
@@ -348,9 +369,44 @@ impl GpuForest {
     /// to call [`predict`] on from a single thread concurrently with `self` or
     /// any other forked handle.
     ///
+    /// The forked handle inherits the [`collect_timeout`] of `self`.
+    ///
     /// [`predict`]: GpuForest::predict
+    /// [`collect_timeout`]: GpuForest::with_collect_timeout
     pub fn fork(&self, max_samples: usize) -> Self {
-        Self::alloc_buffers(Arc::clone(&self.shared), max_samples)
+        let mut forked = Self::alloc_buffers(Arc::clone(&self.shared), max_samples);
+        forked.collect_timeout = self.collect_timeout;
+        forked
+    }
+
+    /// Set the maximum time [`PredictHandle::collect`] will wait for the GPU.
+    ///
+    /// The default is 10 seconds, which is sufficient for normal workloads. For
+    /// very large forests or slow adapters, increase this to avoid spurious panics.
+    ///
+    /// ```rust,no_run
+    /// # use biosphere::{FlatForest, RandomForest, RandomForestParameters};
+    /// # use biosphere::gpu::GpuForest;
+    /// # use ndarray::Array2;
+    /// # let flat = FlatForest::from_forest(
+    /// #     &{ let mut f = RandomForest::new(RandomForestParameters::default());
+    /// #        f.fit(&Array2::<f64>::zeros((2,1)).view(), &ndarray::Array1::zeros(2).view()); f },
+    /// #     1);
+    /// let gpu_forest = GpuForest::from_flat_forest(&flat, 1024)
+    ///     .with_collect_timeout(std::time::Duration::from_secs(60));
+    /// ```
+    pub fn with_collect_timeout(mut self, timeout: Duration) -> Self {
+        self.collect_timeout = timeout;
+        self
+    }
+
+    /// Returns `true` if this forest is running on a unified-memory adapter
+    /// (Apple Silicon, Vulkan UMA, DX12 UMA).
+    ///
+    /// On UMA devices, feature upload and output readback use direct buffer
+    /// mapping instead of staging copies, reducing memory bandwidth usage.
+    pub fn is_uma(&self) -> bool {
+        self.shared.uma
     }
 
     /// Submit a batch inference job to the GPU and return a handle to collect results later.
@@ -366,13 +422,22 @@ impl GpuForest {
     ///
     /// # Panics
     ///
-    /// Panics if `X.nrows() > max_samples` (the value passed to [`GpuForest::from_flat_forest`])
-    /// or if `X.ncols() != n_features`.
+    /// - If `X.nrows() > max_samples` (the value passed to [`GpuForest::from_flat_forest`]).
+    /// - If `X.ncols() != n_features`.
+    /// - If called while a previously returned [`PredictHandle`] has not yet been collected
+    ///   (would overwrite the feature buffer while the GPU is still reading it).
     pub fn predict_submit(&self, X: &ArrayView2<f32>) -> Option<PredictHandle<'_>> {
         let n_samples = X.nrows();
         if n_samples == 0 {
             return None;
         }
+
+        assert!(
+            !self.busy.swap(true, Ordering::Acquire),
+            "predict_submit called on a GpuForest that already has an outstanding PredictHandle; \
+             call collect() on the previous handle before submitting again"
+        );
+
         assert!(
             n_samples <= self.max_samples,
             "n_samples={n_samples} exceeds max_samples={}",
@@ -403,9 +468,9 @@ impl GpuForest {
 
         if shared.uma {
             // UMA path: map feature_buffer directly and write without a staging blit.
-            // The buffer is guaranteed to be free here — the caller must have collected
-            // (or never started) the previous PredictHandle before calling predict_submit
-            // again on the same GpuForest. The poll should return immediately.
+            // The buffer is guaranteed to be free here (enforced by the busy flag above).
+            // Use a bounded 1-second timeout to detect wgpu validation errors that would
+            // otherwise block forever.
             let slice = self.feature_buffer.slice(..feature_bytes);
             slice.map_async(wgpu::MapMode::Write, |r| {
                 r.expect("feature buffer map failed");
@@ -413,9 +478,12 @@ impl GpuForest {
             device
                 .poll(wgpu::PollType::Wait {
                     submission_index: None,
-                    timeout: None,
+                    timeout: Some(Duration::from_secs(1)),
                 })
-                .expect("GPU poll for feature buffer map failed");
+                .expect(
+                    "GPU timed out waiting for UMA feature buffer to become available; \
+                     a wgpu validation error may have occurred",
+                );
             {
                 let mut mapped = slice.get_mapped_range_mut();
                 mapped.copy_from_slice(bytemuck::cast_slice(features));

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -19,6 +19,8 @@ struct GpuForestShared {
     /// Static buffer holding forest metadata. Never mutated after upload.
     meta_buffer: wgpu::Buffer,
     meta: ForestMeta,
+    /// Workgroup size chosen from device limits at pipeline-compile time.
+    workgroup_size: u32,
 }
 
 /// A submitted GPU inference job awaiting results.
@@ -159,6 +161,17 @@ impl GpuForest {
             source: wgpu::ShaderSource::Wgsl(include_str!("shaders/reduce.wgsl").into()),
         });
 
+        // --- Workgroup size ---
+        // Clamp to 256: larger groups rarely help for memory-bandwidth-bound kernels
+        // and can hurt occupancy. Both limits are checked: the per-workgroup cap and
+        // the per-dimension cap (relevant for our 1-D (wg_size, 1, 1) dispatch).
+        let limits = device.limits();
+        let workgroup_size = limits
+            .max_compute_invocations_per_workgroup
+            .min(limits.max_compute_workgroup_size_x)
+            .min(256);
+        let wg_constants = [("wg_size", workgroup_size as f64)];
+
         // --- Compute pipelines ---
         let traverse_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("biosphere::gpu::traverse_layout"),
@@ -171,7 +184,10 @@ impl GpuForest {
             layout: Some(&traverse_layout),
             module: &traverse_shader,
             entry_point: Some("main"),
-            compilation_options: Default::default(),
+            compilation_options: wgpu::PipelineCompilationOptions {
+                constants: &wg_constants,
+                ..Default::default()
+            },
             cache: None,
         });
 
@@ -186,7 +202,10 @@ impl GpuForest {
             layout: Some(&reduce_layout),
             module: &reduce_shader,
             entry_point: Some("main"),
-            compilation_options: Default::default(),
+            compilation_options: wgpu::PipelineCompilationOptions {
+                constants: &wg_constants,
+                ..Default::default()
+            },
             cache: None,
         });
 
@@ -200,6 +219,7 @@ impl GpuForest {
             node_buffer,
             meta_buffer,
             meta: flat.meta,
+            workgroup_size,
         });
 
         Self::alloc_buffers(shared, max_samples)
@@ -363,7 +383,7 @@ impl GpuForest {
             });
             cpass.set_pipeline(&shared.traverse_pipeline);
             cpass.set_bind_group(0, &traverse_bg, &[]);
-            let x_groups = n_samples.div_ceil(64) as u32;
+            let x_groups = n_samples.div_ceil(shared.workgroup_size as usize) as u32;
             cpass.dispatch_workgroups(x_groups, shared.meta.n_trees, 1);
         }
 
@@ -374,7 +394,7 @@ impl GpuForest {
             });
             cpass.set_pipeline(&shared.reduce_pipeline);
             cpass.set_bind_group(0, &reduce_bg, &[]);
-            let x_groups = n_samples.div_ceil(64) as u32;
+            let x_groups = n_samples.div_ceil(shared.workgroup_size as usize) as u32;
             cpass.dispatch_workgroups(x_groups, 1, 1);
         }
 

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -1,9 +1,78 @@
 use crate::flat_forest::{FlatForest, FlatNode, ForestMeta};
 use ndarray::{Array1, ArrayView2};
+use std::fmt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use wgpu::util::DeviceExt;
+
+/// Error returned by [`GpuForest::from_flat_forest`].
+///
+/// Call [`GpuInitError::hints`] for a step-by-step checklist that covers the
+/// most common causes of GPU initialization failures in headless / HPC / SLURM
+/// environments.
+#[derive(Debug)]
+pub struct GpuInitError {
+    message: String,
+    source: Option<wgpu::RequestDeviceError>,
+}
+
+impl GpuInitError {
+    fn no_adapter() -> Self {
+        Self {
+            message: "no suitable GPU adapter found; in headless / HPC / SLURM environments \
+                      this typically means the Vulkan ICD is not linked to the allocated GPU"
+                .to_owned(),
+            source: None,
+        }
+    }
+
+    fn device_creation(e: wgpu::RequestDeviceError) -> Self {
+        // `allowed: 0` for a compute limit means wgpu found no real GPU adapter
+        // with compute support — the Vulkan ICD is not wired up to the allocated
+        // device (common in headless / HPC / SLURM jobs).
+        let dbg = format!("{e:?}");
+        let message = if dbg.contains("allowed: 0") || dbg.contains("LimitsExceeded") {
+            format!(
+                "GPU device creation failed ({e}); `allowed: 0` for a compute limit \
+                 indicates wgpu found no real adapter with compute support — the Vulkan \
+                 ICD is likely not linked to the allocated device"
+            )
+        } else {
+            format!("GPU device creation failed: {e}")
+        };
+        Self { message, source: Some(e) }
+    }
+
+    /// Returns a step-by-step checklist for resolving GPU initialization
+    /// failures in headless / HPC / SLURM environments.
+    ///
+    /// Print this alongside the error to give users actionable next steps:
+    ///
+    /// ```text
+    /// eprintln!("Error: {err}\n\n{}", GpuInitError::hints());
+    /// ```
+    pub fn hints() -> &'static str {
+        "Checklist:\n  \
+         1. Confirm the GPU is allocated (SLURM: `--gres=gpu:1`; verify with `nvidia-smi`).\n  \
+         2. Export the Vulkan ICD explicitly:\n     \
+            export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json\n  \
+         3. Load cluster modules if required (e.g. `module load cuda vulkan`).\n  \
+         4. Confirm Vulkan works inside the job with `vulkaninfo --summary`."
+    }
+}
+
+impl fmt::Display for GpuInitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for GpuInitError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.as_ref().map(|e| e as _)
+    }
+}
 
 /// GPU state shared across all [`GpuForest`] instances forked from the same forest.
 ///
@@ -154,11 +223,17 @@ impl GpuForest {
     /// no precision loss occurs during upload.
     ///
     /// [`predict`]: GpuForest::predict
-    pub fn from_flat_forest(flat: &FlatForest, max_samples: usize) -> Self {
+    pub fn from_flat_forest(
+        flat: &FlatForest,
+        max_samples: usize,
+    ) -> Result<Self, GpuInitError> {
         pollster::block_on(Self::from_flat_forest_async(flat, max_samples))
     }
 
-    async fn from_flat_forest_async(flat: &FlatForest, max_samples: usize) -> Self {
+    async fn from_flat_forest_async(
+        flat: &FlatForest,
+        max_samples: usize,
+    ) -> Result<Self, GpuInitError> {
         // --- Device initialisation ---
         let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor::default());
         let adapter = instance
@@ -168,7 +243,7 @@ impl GpuForest {
                 force_fallback_adapter: false,
             })
             .await
-            .expect("No suitable GPU adapter found");
+            .map_err(|_| GpuInitError::no_adapter())?;
 
         // On unified-memory adapters (Apple Silicon, Vulkan/DX12 UMA) the
         // MAPPABLE_PRIMARY_BUFFERS feature lets us combine STORAGE with MAP_READ
@@ -178,7 +253,7 @@ impl GpuForest {
             .features()
             .contains(wgpu::Features::MAPPABLE_PRIMARY_BUFFERS);
 
-        let (device, queue) = adapter
+        let (device, queue): (wgpu::Device, wgpu::Queue) = adapter
             .request_device(&wgpu::DeviceDescriptor {
                 required_features: if uma {
                     wgpu::Features::MAPPABLE_PRIMARY_BUFFERS
@@ -188,7 +263,7 @@ impl GpuForest {
                 ..Default::default()
             })
             .await
-            .expect("Failed to create GPU device");
+            .map_err(GpuInitError::device_creation)?;
 
         // --- Static buffers ---
         // FlatNode is #[repr(C)] + bytemuck::Pod, so we can upload the node slice
@@ -295,7 +370,7 @@ impl GpuForest {
             uma,
         });
 
-        Self::alloc_buffers(shared, max_samples)
+        Ok(Self::alloc_buffers(shared, max_samples))
     }
 
     /// Allocate the per-instance inference buffers for `max_samples` capacity.
@@ -393,6 +468,7 @@ impl GpuForest {
     /// #        f.fit(&Array2::<f64>::zeros((2,1)).view(), &ndarray::Array1::zeros(2).view()); f },
     /// #     1);
     /// let gpu_forest = GpuForest::from_flat_forest(&flat, 1024)
+    ///     .unwrap()
     ///     .with_collect_timeout(std::time::Duration::from_secs(60));
     /// ```
     pub fn with_collect_timeout(mut self, timeout: Duration) -> Self {

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -1,0 +1,317 @@
+use crate::flat_forest::FlatForest;
+use wgpu::util::DeviceExt;
+
+/// GPU representation of a single node (f32, 16 bytes, bytemuck-compatible).
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+struct GpuNode {
+    feature_index: u32,
+    is_leaf: u32,
+    threshold: f32,
+    leaf_value: f32,
+}
+
+/// Forest metadata passed to every shader invocation.
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+struct ForestMeta {
+    n_trees: u32,
+    n_features: u32,
+    max_tree_size: u32,
+    max_depth: u32,
+}
+
+/// A random forest loaded onto the GPU for batched inference.
+///
+/// Create with [`GpuForest::from_flat_forest`], then call [`GpuForest::predict`].
+pub struct GpuForest {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    traverse_pipeline: wgpu::ComputePipeline,
+    reduce_pipeline: wgpu::ComputePipeline,
+    traverse_bgl: wgpu::BindGroupLayout,
+    reduce_bgl: wgpu::BindGroupLayout,
+    /// Static buffer holding all tree nodes (f32).
+    node_buffer: wgpu::Buffer,
+    /// Static buffer holding forest metadata.
+    meta_buffer: wgpu::Buffer,
+    n_trees: u32,
+}
+
+impl GpuForest {
+    /// Upload a [`FlatForest`] to the GPU and compile the compute pipelines.
+    ///
+    /// Node thresholds and leaf values are downcast from f64 to f32.
+    /// This may introduce small numerical differences compared to CPU inference
+    /// for samples whose feature value is very close to a split threshold.
+    pub fn from_flat_forest(flat: &FlatForest) -> Self {
+        pollster::block_on(Self::from_flat_forest_async(flat))
+    }
+
+    async fn from_flat_forest_async(flat: &FlatForest) -> Self {
+        // --- Device initialisation ---
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor::default());
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter: false,
+            })
+            .await
+            .expect("No suitable GPU adapter found");
+
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor::default())
+            .await
+            .expect("Failed to create GPU device");
+
+        // --- Static buffers ---
+        let gpu_nodes: Vec<GpuNode> = flat
+            .nodes
+            .iter()
+            .map(|n| GpuNode {
+                feature_index: n.feature_index,
+                is_leaf: n.is_leaf as u32,
+                threshold: n.threshold as f32,
+                leaf_value: n.leaf_value as f32,
+            })
+            .collect();
+
+        let node_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("biosphere::gpu::nodes"),
+            contents: bytemuck::cast_slice(&gpu_nodes),
+            usage: wgpu::BufferUsages::STORAGE,
+        });
+
+        let meta = ForestMeta {
+            n_trees: flat.n_trees as u32,
+            n_features: flat.n_features as u32,
+            max_tree_size: flat.max_tree_size as u32,
+            max_depth: flat.max_depth as u32,
+        };
+        let meta_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("biosphere::gpu::meta"),
+            contents: bytemuck::bytes_of(&meta),
+            usage: wgpu::BufferUsages::STORAGE,
+        });
+
+        // --- Bind group layouts ---
+        let traverse_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("biosphere::gpu::traverse_bgl"),
+            entries: &[
+                storage_ro_entry(0),
+                storage_ro_entry(1),
+                storage_ro_entry(2),
+                storage_rw_entry(3),
+            ],
+        });
+
+        let reduce_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("biosphere::gpu::reduce_bgl"),
+            entries: &[storage_ro_entry(0), storage_rw_entry(1)],
+        });
+
+        // --- Shader modules ---
+        let traverse_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("biosphere::gpu::traverse"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/traverse.wgsl").into()),
+        });
+
+        let reduce_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("biosphere::gpu::reduce"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/reduce.wgsl").into()),
+        });
+
+        // --- Compute pipelines ---
+        let traverse_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("biosphere::gpu::traverse_layout"),
+            bind_group_layouts: &[&traverse_bgl],
+            immediate_size: 0,
+        });
+
+        let traverse_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("biosphere::gpu::traverse_pipeline"),
+            layout: Some(&traverse_layout),
+            module: &traverse_shader,
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+        let reduce_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("biosphere::gpu::reduce_layout"),
+            bind_group_layouts: &[&reduce_bgl],
+            immediate_size: 0,
+        });
+
+        let reduce_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("biosphere::gpu::reduce_pipeline"),
+            layout: Some(&reduce_layout),
+            module: &reduce_shader,
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+        GpuForest {
+            device,
+            queue,
+            traverse_pipeline,
+            reduce_pipeline,
+            traverse_bgl,
+            reduce_bgl,
+            node_buffer,
+            meta_buffer,
+            n_trees: flat.n_trees as u32,
+        }
+    }
+
+    /// Run batched inference on `n_samples` samples.
+    ///
+    /// `features` is a row-major f32 matrix of shape `(n_samples, n_features)`.
+    /// Returns one f32 prediction per sample (mean of all tree predictions).
+    pub fn predict(&self, features: &[f32], n_samples: usize) -> Vec<f32> {
+        pollster::block_on(self.predict_async(features, n_samples))
+    }
+
+    async fn predict_async(&self, features: &[f32], n_samples: usize) -> Vec<f32> {
+        let device = &self.device;
+        let queue = &self.queue;
+
+        // --- Per-call buffers ---
+        let feature_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("biosphere::gpu::features"),
+            contents: bytemuck::cast_slice(features),
+            usage: wgpu::BufferUsages::STORAGE,
+        });
+
+        let per_tree_preds_size = (n_samples * self.n_trees as usize * size_of::<f32>()) as u64;
+        let per_tree_preds_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("biosphere::gpu::per_tree_preds"),
+            size: per_tree_preds_size,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+
+        let output_size = (n_samples * size_of::<f32>()) as u64;
+        let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("biosphere::gpu::output"),
+            size: output_size,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+
+        let staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("biosphere::gpu::staging"),
+            size: output_size,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        // --- Bind groups ---
+        let traverse_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("biosphere::gpu::traverse_bg"),
+            layout: &self.traverse_bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: self.meta_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: self.node_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: feature_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: per_tree_preds_buffer.as_entire_binding(),
+                },
+            ],
+        });
+
+        let reduce_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("biosphere::gpu::reduce_bg"),
+            layout: &self.reduce_bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: per_tree_preds_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: output_buffer.as_entire_binding(),
+                },
+            ],
+        });
+
+        // --- Encode and submit ---
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+        {
+            let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("biosphere::gpu::traverse_pass"),
+                timestamp_writes: None,
+            });
+            cpass.set_pipeline(&self.traverse_pipeline);
+            cpass.set_bind_group(0, &traverse_bg, &[]);
+            let x_groups = n_samples.div_ceil(64) as u32;
+            cpass.dispatch_workgroups(x_groups, self.n_trees, 1);
+        }
+
+        {
+            let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("biosphere::gpu::reduce_pass"),
+                timestamp_writes: None,
+            });
+            cpass.set_pipeline(&self.reduce_pipeline);
+            cpass.set_bind_group(0, &reduce_bg, &[]);
+            let x_groups = n_samples.div_ceil(64) as u32;
+            cpass.dispatch_workgroups(x_groups, 1, 1);
+        }
+
+        encoder.copy_buffer_to_buffer(&output_buffer, 0, &staging_buffer, 0, output_size);
+        queue.submit(Some(encoder.finish()));
+
+        // --- Read results ---
+        let buffer_slice = staging_buffer.slice(..);
+        buffer_slice.map_async(wgpu::MapMode::Read, |_| {});
+        device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .expect("GPU poll failed");
+
+        let data = buffer_slice.get_mapped_range();
+        bytemuck::cast_slice::<u8, f32>(&data).to_vec()
+    }
+}
+
+// --- Helpers ---
+
+fn storage_ro_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only: true },
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}
+
+fn storage_rw_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only: false },
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -275,7 +275,7 @@ impl GpuForest {
     ///
     /// # Panics
     ///
-    /// Panics if `n_samples > max_samples` (the value passed to [`from_flat_forest`]).
+    /// Panics if `n_samples > max_samples` (the value passed to [`GpuForest::from_flat_forest`]).
     pub fn predict(&self, features: &[f32], n_samples: usize) -> Vec<f32> {
         if n_samples == 0 {
             return vec![];
@@ -384,7 +384,13 @@ impl GpuForest {
             cpass.dispatch_workgroups(x_groups, 1, 1);
         }
 
-        encoder.copy_buffer_to_buffer(&self.output_buffer, 0, &self.staging_buffer, 0, output_bytes);
+        encoder.copy_buffer_to_buffer(
+            &self.output_buffer,
+            0,
+            &self.staging_buffer,
+            0,
+            output_bytes,
+        );
         let submit_idx = queue.submit(Some(encoder.finish()));
 
         // --- Read results ---

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -45,7 +45,10 @@ impl GpuInitError {
         } else {
             format!("GPU device creation failed: {e}")
         };
-        Self { message, source: Some(e) }
+        Self {
+            message,
+            source: Some(e),
+        }
     }
 
     /// Returns a step-by-step checklist for resolving GPU initialization
@@ -457,10 +460,7 @@ impl GpuForest {
     /// no precision loss occurs during upload.
     ///
     /// [`predict`]: GpuForest::predict
-    pub fn from_flat_forest(
-        flat: &FlatForest,
-        max_samples: usize,
-    ) -> Result<Self, GpuInitError> {
+    pub fn from_flat_forest(flat: &FlatForest, max_samples: usize) -> Result<Self, GpuInitError> {
         let ctx = GpuContext::new()?;
         Ok(Self::with_context(ctx, flat, max_samples))
     }

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -1,30 +1,6 @@
-use crate::flat_forest::FlatForest;
+use crate::flat_forest::{FlatForest, FlatNode, ForestMeta};
 use std::sync::Arc;
 use wgpu::util::DeviceExt;
-
-/// GPU representation of a single node (f32/i32, 24 bytes, bytemuck-compatible).
-#[repr(C)]
-#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
-struct GpuNode {
-    feature_index: u32,
-    is_leaf: u32,
-    threshold: f32,
-    leaf_value: f32,
-    /// Left child index within the tree's node slice, or -1 for leaves.
-    left: i32,
-    /// Right child index within the tree's node slice, or -1 for leaves.
-    right: i32,
-}
-
-/// Forest metadata passed to every shader invocation.
-#[repr(C)]
-#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-struct ForestMeta {
-    n_trees: u32,
-    n_features: u32,
-    max_tree_size: u32,
-    max_depth: u32,
-}
 
 /// GPU state shared across all [`GpuForest`] instances forked from the same forest.
 ///
@@ -38,12 +14,11 @@ struct GpuForestShared {
     reduce_pipeline: wgpu::ComputePipeline,
     traverse_bgl: wgpu::BindGroupLayout,
     reduce_bgl: wgpu::BindGroupLayout,
-    /// Static buffer holding all tree nodes (f32). Never mutated after upload.
+    /// Static buffer holding all tree nodes. Never mutated after upload.
     node_buffer: wgpu::Buffer,
     /// Static buffer holding forest metadata. Never mutated after upload.
     meta_buffer: wgpu::Buffer,
-    n_trees: u32,
-    n_features: u32,
+    meta: ForestMeta,
 }
 
 /// A submitted GPU inference job awaiting results.
@@ -116,9 +91,8 @@ impl GpuForest {
     /// All GPU inference buffers are pre-allocated at this capacity, so individual
     /// `predict` calls avoid any GPU memory allocation overhead.
     ///
-    /// Node thresholds and leaf values are downcast from f64 to f32.
-    /// This may introduce small numerical differences compared to CPU inference
-    /// for samples whose feature value is very close to a split threshold.
+    /// Node thresholds and leaf values are already `f32` in [`FlatForest`], so
+    /// no precision loss occurs during upload.
     ///
     /// [`predict`]: GpuForest::predict
     pub fn from_flat_forest(flat: &FlatForest, max_samples: usize) -> Self {
@@ -143,35 +117,18 @@ impl GpuForest {
             .expect("Failed to create GPU device");
 
         // --- Static buffers ---
-        let gpu_nodes: Vec<GpuNode> = flat
-            .nodes
-            .iter()
-            .map(|n| GpuNode {
-                feature_index: n.feature_index,
-                // FlatNode no longer carries is_leaf; derive it from left < 0.
-                is_leaf: (n.left < 0) as u32,
-                threshold: n.threshold as f32,
-                leaf_value: n.leaf_value as f32,
-                left: n.left,
-                right: n.right,
-            })
-            .collect();
-
+        // FlatNode is #[repr(C)] + bytemuck::Pod, so we can upload the node slice
+        // directly without any conversion.
         let node_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("biosphere::gpu::nodes"),
-            contents: bytemuck::cast_slice(&gpu_nodes),
+            contents: bytemuck::cast_slice::<FlatNode, u8>(&flat.nodes),
             usage: wgpu::BufferUsages::STORAGE,
         });
 
-        let meta = ForestMeta {
-            n_trees: flat.n_trees as u32,
-            n_features: flat.n_features as u32,
-            max_tree_size: flat.max_tree_size as u32,
-            max_depth: flat.max_depth as u32,
-        };
+        // ForestMeta is #[repr(C)] + bytemuck::Pod; upload directly.
         let meta_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("biosphere::gpu::meta"),
-            contents: bytemuck::bytes_of(&meta),
+            contents: bytemuck::bytes_of(&flat.meta),
             usage: wgpu::BufferUsages::STORAGE,
         });
 
@@ -242,8 +199,7 @@ impl GpuForest {
             reduce_bgl,
             node_buffer,
             meta_buffer,
-            n_trees: flat.n_trees as u32,
-            n_features: flat.n_features as u32,
+            meta: flat.meta,
         });
 
         Self::alloc_buffers(shared, max_samples)
@@ -252,8 +208,8 @@ impl GpuForest {
     /// Allocate the per-instance inference buffers for `max_samples` capacity.
     fn alloc_buffers(shared: Arc<GpuForestShared>, max_samples: usize) -> Self {
         let device = &shared.device;
-        let n_trees = shared.n_trees as usize;
-        let n_features = shared.n_features as usize;
+        let n_trees = shared.meta.n_trees as usize;
+        let n_features = shared.meta.n_features as usize;
 
         let feature_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("biosphere::gpu::features"),
@@ -332,8 +288,8 @@ impl GpuForest {
         let shared = &self.shared;
         let device = &shared.device;
         let queue = &shared.queue;
-        let n_features = shared.n_features as usize;
-        let n_trees = shared.n_trees as usize;
+        let n_features = shared.meta.n_features as usize;
+        let n_trees = shared.meta.n_trees as usize;
 
         let feature_bytes = (n_samples * n_features * size_of::<f32>()) as u64;
         let per_tree_bytes = (n_samples * n_trees * size_of::<f32>()) as u64;
@@ -408,7 +364,7 @@ impl GpuForest {
             cpass.set_pipeline(&shared.traverse_pipeline);
             cpass.set_bind_group(0, &traverse_bg, &[]);
             let x_groups = n_samples.div_ceil(64) as u32;
-            cpass.dispatch_workgroups(x_groups, shared.n_trees, 1);
+            cpass.dispatch_workgroups(x_groups, shared.meta.n_trees, 1);
         }
 
         {

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -1,4 +1,5 @@
 use crate::flat_forest::FlatForest;
+use std::sync::Arc;
 use wgpu::util::DeviceExt;
 
 /// GPU representation of a single node (f32/i32, 24 bytes, bytemuck-compatible).
@@ -25,34 +26,69 @@ struct ForestMeta {
     max_depth: u32,
 }
 
-/// A random forest loaded onto the GPU for batched inference.
+/// GPU state shared across all [`GpuForest`] instances forked from the same forest.
 ///
-/// Create with [`GpuForest::from_flat_forest`], then call [`GpuForest::predict`].
-pub struct GpuForest {
+/// Holds the GPU device, compiled pipelines, and static node/meta buffers.
+/// Wrapped in [`Arc`] so [`GpuForest::fork`] avoids re-uploading node data or
+/// recompiling shaders when creating per-thread handles.
+struct GpuForestShared {
     device: wgpu::Device,
     queue: wgpu::Queue,
     traverse_pipeline: wgpu::ComputePipeline,
     reduce_pipeline: wgpu::ComputePipeline,
     traverse_bgl: wgpu::BindGroupLayout,
     reduce_bgl: wgpu::BindGroupLayout,
-    /// Static buffer holding all tree nodes (f32).
+    /// Static buffer holding all tree nodes (f32). Never mutated after upload.
     node_buffer: wgpu::Buffer,
-    /// Static buffer holding forest metadata.
+    /// Static buffer holding forest metadata. Never mutated after upload.
     meta_buffer: wgpu::Buffer,
     n_trees: u32,
+    n_features: u32,
+}
+
+/// A random forest loaded onto the GPU for batched inference.
+///
+/// Create with [`GpuForest::from_flat_forest`], then call [`GpuForest::predict`].
+///
+/// Use [`GpuForest::fork`] to create per-thread handles that share compiled
+/// pipelines and uploaded node data without re-uploading or recompiling.
+/// Each handle has its own pre-allocated GPU inference buffers and is safe
+/// to use from a single thread concurrently with other handles forked from
+/// the same forest.
+pub struct GpuForest {
+    shared: Arc<GpuForestShared>,
+    /// Pre-allocated feature upload buffer (STORAGE | COPY_DST).
+    /// Sized for `max_samples * n_features * 4` bytes.
+    feature_buffer: wgpu::Buffer,
+    /// Pre-allocated intermediate per-tree predictions (STORAGE).
+    /// Sized for `max_samples * n_trees * 4` bytes.
+    per_tree_preds_buffer: wgpu::Buffer,
+    /// Pre-allocated final per-sample means (STORAGE | COPY_SRC).
+    /// Sized for `max_samples * 4` bytes.
+    output_buffer: wgpu::Buffer,
+    /// Pre-allocated CPU-readable staging buffer (COPY_DST | MAP_READ).
+    /// Sized for `max_samples * 4` bytes.
+    staging_buffer: wgpu::Buffer,
+    max_samples: usize,
 }
 
 impl GpuForest {
     /// Upload a [`FlatForest`] to the GPU and compile the compute pipelines.
     ///
+    /// `max_samples` is the maximum batch size for a single [`predict`] call.
+    /// All GPU inference buffers are pre-allocated at this capacity, so individual
+    /// `predict` calls avoid any GPU memory allocation overhead.
+    ///
     /// Node thresholds and leaf values are downcast from f64 to f32.
     /// This may introduce small numerical differences compared to CPU inference
     /// for samples whose feature value is very close to a split threshold.
-    pub fn from_flat_forest(flat: &FlatForest) -> Self {
-        pollster::block_on(Self::from_flat_forest_async(flat))
+    ///
+    /// [`predict`]: GpuForest::predict
+    pub fn from_flat_forest(flat: &FlatForest, max_samples: usize) -> Self {
+        pollster::block_on(Self::from_flat_forest_async(flat, max_samples))
     }
 
-    async fn from_flat_forest_async(flat: &FlatForest) -> Self {
+    async fn from_flat_forest_async(flat: &FlatForest, max_samples: usize) -> Self {
         // --- Device initialisation ---
         let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor::default());
         let adapter = instance
@@ -159,7 +195,7 @@ impl GpuForest {
             cache: None,
         });
 
-        GpuForest {
+        let shared = Arc::new(GpuForestShared {
             device,
             queue,
             traverse_pipeline,
@@ -169,86 +205,155 @@ impl GpuForest {
             node_buffer,
             meta_buffer,
             n_trees: flat.n_trees as u32,
-        }
-    }
-
-    /// Run batched inference on `n_samples` samples.
-    ///
-    /// `features` is a row-major f32 matrix of shape `(n_samples, n_features)`.
-    /// Returns one f32 prediction per sample (mean of all tree predictions).
-    pub fn predict(&self, features: &[f32], n_samples: usize) -> Vec<f32> {
-        pollster::block_on(self.predict_async(features, n_samples))
-    }
-
-    async fn predict_async(&self, features: &[f32], n_samples: usize) -> Vec<f32> {
-        let device = &self.device;
-        let queue = &self.queue;
-
-        // --- Per-call buffers ---
-        let feature_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("biosphere::gpu::features"),
-            contents: bytemuck::cast_slice(features),
-            usage: wgpu::BufferUsages::STORAGE,
+            n_features: flat.n_features as u32,
         });
 
-        let per_tree_preds_size = (n_samples * self.n_trees as usize * size_of::<f32>()) as u64;
-        let per_tree_preds_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("biosphere::gpu::per_tree_preds"),
-            size: per_tree_preds_size,
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        Self::alloc_buffers(shared, max_samples)
+    }
+
+    /// Allocate the per-instance inference buffers for `max_samples` capacity.
+    fn alloc_buffers(shared: Arc<GpuForestShared>, max_samples: usize) -> Self {
+        let device = &shared.device;
+        let n_trees = shared.n_trees as usize;
+        let n_features = shared.n_features as usize;
+
+        let feature_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("biosphere::gpu::features"),
+            size: (max_samples * n_features * size_of::<f32>()) as u64,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
-        let output_size = (n_samples * size_of::<f32>()) as u64;
+        let per_tree_preds_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("biosphere::gpu::per_tree_preds"),
+            size: (max_samples * n_trees * size_of::<f32>()) as u64,
+            usage: wgpu::BufferUsages::STORAGE,
+            mapped_at_creation: false,
+        });
+
         let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("biosphere::gpu::output"),
-            size: output_size,
+            size: (max_samples * size_of::<f32>()) as u64,
             usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
             mapped_at_creation: false,
         });
 
         let staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("biosphere::gpu::staging"),
-            size: output_size,
+            size: (max_samples * size_of::<f32>()) as u64,
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             mapped_at_creation: false,
         });
 
-        // --- Bind groups ---
+        GpuForest {
+            shared,
+            feature_buffer,
+            per_tree_preds_buffer,
+            output_buffer,
+            staging_buffer,
+            max_samples,
+        }
+    }
+
+    /// Create a new `GpuForest` handle for use from a separate thread.
+    ///
+    /// The returned handle shares the compiled GPU pipelines and uploaded node
+    /// data with `self` (no recompilation or re-upload). It gets its own
+    /// pre-allocated inference buffers sized for `max_samples`, making it safe
+    /// to call [`predict`] on from a single thread concurrently with `self` or
+    /// any other forked handle.
+    ///
+    /// [`predict`]: GpuForest::predict
+    pub fn fork(&self, max_samples: usize) -> Self {
+        Self::alloc_buffers(Arc::clone(&self.shared), max_samples)
+    }
+
+    /// Run batched inference on `n_samples` samples.
+    ///
+    /// `features` is a row-major f32 slice of shape `(n_samples, n_features)`.
+    /// Returns one f32 prediction per sample (mean of all tree predictions).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n_samples > max_samples` (the value passed to [`from_flat_forest`]).
+    pub fn predict(&self, features: &[f32], n_samples: usize) -> Vec<f32> {
+        if n_samples == 0 {
+            return vec![];
+        }
+        assert!(
+            n_samples <= self.max_samples,
+            "n_samples={n_samples} exceeds max_samples={}",
+            self.max_samples
+        );
+        pollster::block_on(self.predict_async(features, n_samples))
+    }
+
+    async fn predict_async(&self, features: &[f32], n_samples: usize) -> Vec<f32> {
+        let shared = &self.shared;
+        let device = &shared.device;
+        let queue = &shared.queue;
+        let n_features = shared.n_features as usize;
+        let n_trees = shared.n_trees as usize;
+
+        let feature_bytes = (n_samples * n_features * size_of::<f32>()) as u64;
+        let per_tree_bytes = (n_samples * n_trees * size_of::<f32>()) as u64;
+        let output_bytes = (n_samples * size_of::<f32>()) as u64;
+
+        // Upload features into the pre-allocated buffer.
+        queue.write_buffer(&self.feature_buffer, 0, bytemuck::cast_slice(features));
+
+        // Create bind groups with sub-range sizes so that arrayLength() in the
+        // shaders reflects the actual n_samples, not the full max_samples capacity.
         let traverse_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("biosphere::gpu::traverse_bg"),
-            layout: &self.traverse_bgl,
+            label: None,
+            layout: &shared.traverse_bgl,
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,
-                    resource: self.meta_buffer.as_entire_binding(),
+                    resource: shared.meta_buffer.as_entire_binding(),
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: self.node_buffer.as_entire_binding(),
+                    resource: shared.node_buffer.as_entire_binding(),
                 },
                 wgpu::BindGroupEntry {
                     binding: 2,
-                    resource: feature_buffer.as_entire_binding(),
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &self.feature_buffer,
+                        offset: 0,
+                        size: wgpu::BufferSize::new(feature_bytes),
+                    }),
                 },
                 wgpu::BindGroupEntry {
                     binding: 3,
-                    resource: per_tree_preds_buffer.as_entire_binding(),
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &self.per_tree_preds_buffer,
+                        offset: 0,
+                        size: wgpu::BufferSize::new(per_tree_bytes),
+                    }),
                 },
             ],
         });
 
         let reduce_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("biosphere::gpu::reduce_bg"),
-            layout: &self.reduce_bgl,
+            label: None,
+            layout: &shared.reduce_bgl,
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,
-                    resource: per_tree_preds_buffer.as_entire_binding(),
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &self.per_tree_preds_buffer,
+                        offset: 0,
+                        size: wgpu::BufferSize::new(per_tree_bytes),
+                    }),
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: output_buffer.as_entire_binding(),
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &self.output_buffer,
+                        offset: 0,
+                        size: wgpu::BufferSize::new(output_bytes),
+                    }),
                 },
             ],
         });
@@ -262,10 +367,10 @@ impl GpuForest {
                 label: Some("biosphere::gpu::traverse_pass"),
                 timestamp_writes: None,
             });
-            cpass.set_pipeline(&self.traverse_pipeline);
+            cpass.set_pipeline(&shared.traverse_pipeline);
             cpass.set_bind_group(0, &traverse_bg, &[]);
             let x_groups = n_samples.div_ceil(64) as u32;
-            cpass.dispatch_workgroups(x_groups, self.n_trees, 1);
+            cpass.dispatch_workgroups(x_groups, shared.n_trees, 1);
         }
 
         {
@@ -273,24 +378,32 @@ impl GpuForest {
                 label: Some("biosphere::gpu::reduce_pass"),
                 timestamp_writes: None,
             });
-            cpass.set_pipeline(&self.reduce_pipeline);
+            cpass.set_pipeline(&shared.reduce_pipeline);
             cpass.set_bind_group(0, &reduce_bg, &[]);
             let x_groups = n_samples.div_ceil(64) as u32;
             cpass.dispatch_workgroups(x_groups, 1, 1);
         }
 
-        encoder.copy_buffer_to_buffer(&output_buffer, 0, &staging_buffer, 0, output_size);
-        queue.submit(Some(encoder.finish()));
+        encoder.copy_buffer_to_buffer(&self.output_buffer, 0, &self.staging_buffer, 0, output_bytes);
+        let submit_idx = queue.submit(Some(encoder.finish()));
 
         // --- Read results ---
-        let buffer_slice = staging_buffer.slice(..);
+        // Map only the used portion of the pre-allocated staging buffer.
+        let buffer_slice = self.staging_buffer.slice(..output_bytes);
         buffer_slice.map_async(wgpu::MapMode::Read, |_| {});
+        // Wait for exactly our submission — safe even with a shared device/queue.
         device
-            .poll(wgpu::PollType::wait_indefinitely())
+            .poll(wgpu::PollType::Wait {
+                submission_index: Some(submit_idx),
+                timeout: None,
+            })
             .expect("GPU poll failed");
 
         let data = buffer_slice.get_mapped_range();
-        bytemuck::cast_slice::<u8, f32>(&data).to_vec()
+        let result = bytemuck::cast_slice::<u8, f32>(&data).to_vec();
+        drop(data);
+        self.staging_buffer.unmap();
+        result
     }
 }
 

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -6,7 +6,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use wgpu::util::DeviceExt;
 
-/// Error returned by [`GpuForest::from_flat_forest`].
+// ---------------------------------------------------------------------------
+// GpuInitError
+// ---------------------------------------------------------------------------
+
+/// Error returned by [`GpuContext::new`] and [`GpuForest::from_flat_forest`].
 ///
 /// Call [`GpuInitError::hints`] for a step-by-step checklist that covers the
 /// most common causes of GPU initialization failures in headless / HPC / SLURM
@@ -74,23 +78,26 @@ impl std::error::Error for GpuInitError {
     }
 }
 
-/// GPU state shared across all [`GpuForest`] instances forked from the same forest.
+// ---------------------------------------------------------------------------
+// GpuContext
+// ---------------------------------------------------------------------------
+
+/// A shareable GPU device context: wgpu device, queue, and compiled compute
+/// pipelines.
 ///
-/// Holds the GPU device, compiled pipelines, and static node/meta buffers.
-/// Wrapped in [`Arc`] so [`GpuForest::fork`] avoids re-uploading node data or
-/// recompiling shaders when creating per-thread handles.
-struct GpuForestShared {
+/// Create once with [`GpuContext::new`] and pass the returned `Arc<GpuContext>`
+/// to multiple [`GpuForest::with_context`] calls to avoid redundant GPU
+/// initialisation and shader recompilation across forests.
+///
+/// When you only have a single forest, [`GpuForest::from_flat_forest`] creates
+/// a context internally and is simpler to use.
+pub struct GpuContext {
     device: wgpu::Device,
     queue: wgpu::Queue,
     traverse_pipeline: wgpu::ComputePipeline,
     reduce_pipeline: wgpu::ComputePipeline,
     traverse_bgl: wgpu::BindGroupLayout,
     reduce_bgl: wgpu::BindGroupLayout,
-    /// Static buffer holding all tree nodes. Never mutated after upload.
-    node_buffer: wgpu::Buffer,
-    /// Static buffer holding forest metadata. Never mutated after upload.
-    meta_buffer: wgpu::Buffer,
-    meta: ForestMeta,
     /// Workgroup size chosen from device limits at pipeline-compile time.
     workgroup_size: u32,
     /// True when the adapter supports `MAPPABLE_PRIMARY_BUFFERS` (Apple Silicon,
@@ -100,141 +107,24 @@ struct GpuForestShared {
     uma: bool,
 }
 
-/// A submitted GPU inference job awaiting results.
-///
-/// Created by [`GpuForest::predict_submit`]. Call [`PredictHandle::collect`] to
-/// wait for the GPU to finish and retrieve the predictions.
-///
-/// Submitting multiple handles before calling `collect` on any of them lets the
-/// GPU execute the underlying work concurrently.
-pub struct PredictHandle<'forest> {
-    forest: &'forest GpuForest,
-    submit_idx: wgpu::SubmissionIndex,
-    output_bytes: u64,
-}
-
-impl<'forest> PredictHandle<'forest> {
-    /// Block until the GPU finishes this submission and return the predictions.
+impl GpuContext {
+    /// Initialise a GPU device and compile the compute pipelines.
     ///
-    /// One `f32` per sample, in the same order as the input to [`GpuForest::predict_submit`].
+    /// Selects the highest-performance available adapter. Returns an
+    /// `Arc<GpuContext>` that can be passed to any number of
+    /// [`GpuForest::with_context`] calls.
     ///
-    /// Panics if the GPU does not complete within the timeout configured via
-    /// [`GpuForest::with_collect_timeout`] (default: 10 seconds).
-    pub fn collect(self) -> Array1<f32> {
-        let device = &self.forest.shared.device;
-        let timeout = self.forest.collect_timeout;
-
-        let result = if self.forest.shared.uma {
-            // UMA path: output_buffer has MAP_READ usage, so we read directly
-            // without a staging copy. The poll also waits for the GPU submission.
-            let slice = self.forest.output_buffer.slice(..self.output_bytes);
-            slice.map_async(wgpu::MapMode::Read, |r| {
-                r.expect("GPU output buffer mapping failed");
-            });
-            device
-                .poll(wgpu::PollType::Wait {
-                    submission_index: Some(self.submit_idx),
-                    timeout: Some(timeout),
-                })
-                .expect("GPU timed out during inference; consider increasing the timeout with GpuForest::with_collect_timeout");
-            let data = slice.get_mapped_range();
-            let result = Array1::from(bytemuck::cast_slice::<u8, f32>(&data).to_vec());
-            drop(data);
-            self.forest.output_buffer.unmap();
-            result
-        } else {
-            // Discrete GPU path: results were copied to the staging buffer by the
-            // command encoder; map that and read back.
-            let staging = self.forest.staging_buffer.as_ref().unwrap();
-            let buffer_slice = staging.slice(..self.output_bytes);
-            buffer_slice.map_async(wgpu::MapMode::Read, |result| {
-                result.expect("GPU staging buffer mapping failed");
-            });
-            device
-                .poll(wgpu::PollType::Wait {
-                    submission_index: Some(self.submit_idx),
-                    timeout: Some(timeout),
-                })
-                .expect("GPU timed out during inference; consider increasing the timeout with GpuForest::with_collect_timeout");
-            let data = buffer_slice.get_mapped_range();
-            let result = Array1::from(bytemuck::cast_slice::<u8, f32>(&data).to_vec());
-            drop(data);
-            staging.unmap();
-            result
-        };
-
-        // Release the busy flag so predict_submit can be called again.
-        self.forest.busy.store(false, Ordering::Release);
-        result
-    }
-}
-
-/// A random forest loaded onto the GPU for batched inference.
-///
-/// Create with [`GpuForest::from_flat_forest`], then call [`GpuForest::predict`].
-///
-/// Use [`GpuForest::fork`] to create per-thread handles that share compiled
-/// pipelines and uploaded node data without re-uploading or recompiling.
-/// Each handle has its own pre-allocated GPU inference buffers and is safe
-/// to use from a single thread concurrently with other handles forked from
-/// the same forest.
-pub struct GpuForest {
-    shared: Arc<GpuForestShared>,
-    /// Pre-allocated feature buffer.
-    /// UMA: `STORAGE | MAP_WRITE` — CPU writes directly via mapping.
-    /// Discrete: `STORAGE | COPY_DST` — written via `queue.write_buffer`.
-    /// Sized for `max_samples * n_features * 4` bytes.
-    feature_buffer: wgpu::Buffer,
-    /// Pre-allocated intermediate per-tree predictions (STORAGE).
-    /// Sized for `max_samples * n_trees * 4` bytes.
-    per_tree_preds_buffer: wgpu::Buffer,
-    /// Pre-allocated final per-sample means.
-    /// UMA: `STORAGE | MAP_READ` — CPU reads directly; no staging copy needed.
-    /// Discrete: `STORAGE | COPY_SRC` — copied to staging buffer before readback.
-    /// Sized for `max_samples * 4` bytes.
-    output_buffer: wgpu::Buffer,
-    /// CPU-readable staging buffer for discrete GPUs. `None` on UMA devices.
-    /// Discrete: `COPY_DST | MAP_READ`, sized for `max_samples * 4` bytes.
-    staging_buffer: Option<wgpu::Buffer>,
-    max_samples: usize,
-    /// Maximum time [`PredictHandle::collect`] will wait for the GPU.
-    /// Default: 10 seconds.
-    collect_timeout: Duration,
-    /// Set to `true` while a [`PredictHandle`] is outstanding. Guards against
-    /// calling [`predict_submit`] again before the previous handle is collected,
-    /// which would overwrite the feature buffer while the GPU may still read it.
+    /// # Errors
     ///
-    /// [`predict_submit`]: GpuForest::predict_submit
-    busy: AtomicBool,
-}
-
-impl GpuForest {
-    /// Upload a [`FlatForest`] to the GPU and compile the compute pipelines.
-    ///
-    /// `max_samples` is the maximum batch size for a single [`predict`] call.
-    /// All GPU inference buffers are pre-allocated at this capacity, so individual
-    /// `predict` calls avoid any GPU memory allocation overhead.
-    ///
-    /// On Apple Silicon and other unified-memory adapters, feature upload and
-    /// output readback use direct buffer mapping instead of staging copies,
-    /// eliminating redundant data movement within the shared memory pool.
-    ///
-    /// Node thresholds and leaf values are already `f32` in [`FlatForest`], so
-    /// no precision loss occurs during upload.
-    ///
-    /// [`predict`]: GpuForest::predict
-    pub fn from_flat_forest(
-        flat: &FlatForest,
-        max_samples: usize,
-    ) -> Result<Self, GpuInitError> {
-        pollster::block_on(Self::from_flat_forest_async(flat, max_samples))
+    /// Returns [`GpuInitError`] if no suitable adapter is found or the device
+    /// cannot be created. Call [`GpuInitError::hints`] for an HPC/SLURM
+    /// troubleshooting checklist.
+    pub fn new() -> Result<Arc<Self>, GpuInitError> {
+        pollster::block_on(Self::new_async())
     }
 
-    async fn from_flat_forest_async(
-        flat: &FlatForest,
-        max_samples: usize,
-    ) -> Result<Self, GpuInitError> {
-        // --- Device initialisation ---
+    async fn new_async() -> Result<Arc<Self>, GpuInitError> {
+        // --- Adapter ---
         let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor::default());
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
@@ -264,22 +154,6 @@ impl GpuForest {
             })
             .await
             .map_err(GpuInitError::device_creation)?;
-
-        // --- Static buffers ---
-        // FlatNode is #[repr(C)] + bytemuck::Pod, so we can upload the node slice
-        // directly without any conversion.
-        let node_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("biosphere::gpu::nodes"),
-            contents: bytemuck::cast_slice::<FlatNode, u8>(&flat.nodes),
-            usage: wgpu::BufferUsages::STORAGE,
-        });
-
-        // ForestMeta is #[repr(C)] + bytemuck::Pod; upload directly.
-        let meta_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("biosphere::gpu::meta"),
-            contents: bytemuck::bytes_of(&flat.meta),
-            usage: wgpu::BufferUsages::STORAGE,
-        });
 
         // --- Bind group layouts ---
         let traverse_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -356,29 +230,247 @@ impl GpuForest {
             cache: None,
         });
 
-        let shared = Arc::new(GpuForestShared {
+        Ok(Arc::new(GpuContext {
             device,
             queue,
             traverse_pipeline,
             reduce_pipeline,
             traverse_bgl,
             reduce_bgl,
+            workgroup_size,
+            uma,
+        }))
+    }
+
+    /// Returns `true` if the underlying adapter is a unified-memory device
+    /// (Apple Silicon, Vulkan UMA, DX12 UMA).
+    ///
+    /// On UMA devices, feature upload and output readback use direct buffer
+    /// mapping instead of staging copies, reducing memory bandwidth usage.
+    pub fn is_uma(&self) -> bool {
+        self.uma
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GpuForestShared / GpuForest / PredictHandle
+// ---------------------------------------------------------------------------
+
+/// Per-forest GPU state shared across all [`GpuForest`] instances forked from
+/// the same forest.
+///
+/// Holds the static per-forest node/meta buffers and a reference to the
+/// [`GpuContext`] (device, pipelines). Wrapped in [`Arc`] so
+/// [`GpuForest::fork`] avoids re-uploading node data when creating per-thread
+/// handles.
+struct GpuForestShared {
+    /// Shared device, queue, and compiled pipelines.
+    ctx: Arc<GpuContext>,
+    /// Static buffer holding all tree nodes. Never mutated after upload.
+    node_buffer: wgpu::Buffer,
+    /// Static buffer holding forest metadata. Never mutated after upload.
+    meta_buffer: wgpu::Buffer,
+    meta: ForestMeta,
+}
+
+/// A submitted GPU inference job awaiting results.
+///
+/// Created by [`GpuForest::predict_submit`]. Call [`PredictHandle::collect`] to
+/// wait for the GPU to finish and retrieve the predictions.
+///
+/// Submitting multiple handles before calling `collect` on any of them lets the
+/// GPU execute the underlying work concurrently.
+pub struct PredictHandle<'forest> {
+    forest: &'forest GpuForest,
+    submit_idx: wgpu::SubmissionIndex,
+    output_bytes: u64,
+}
+
+impl<'forest> PredictHandle<'forest> {
+    /// Block until the GPU finishes this submission and return the predictions.
+    ///
+    /// One `f32` per sample, in the same order as the input to [`GpuForest::predict_submit`].
+    ///
+    /// Panics if the GPU does not complete within the timeout configured via
+    /// [`GpuForest::with_collect_timeout`] (default: 10 seconds).
+    pub fn collect(self) -> Array1<f32> {
+        let device = &self.forest.shared.ctx.device;
+        let timeout = self.forest.collect_timeout;
+
+        let result = if self.forest.shared.ctx.uma {
+            // UMA path: output_buffer has MAP_READ usage, so we read directly
+            // without a staging copy. The poll also waits for the GPU submission.
+            let slice = self.forest.output_buffer.slice(..self.output_bytes);
+            slice.map_async(wgpu::MapMode::Read, |r| {
+                r.expect("GPU output buffer mapping failed");
+            });
+            device
+                .poll(wgpu::PollType::Wait {
+                    submission_index: Some(self.submit_idx),
+                    timeout: Some(timeout),
+                })
+                .expect("GPU timed out during inference; consider increasing the timeout with GpuForest::with_collect_timeout");
+            let data = slice.get_mapped_range();
+            let result = Array1::from(bytemuck::cast_slice::<u8, f32>(&data).to_vec());
+            drop(data);
+            self.forest.output_buffer.unmap();
+            result
+        } else {
+            // Discrete GPU path: results were copied to the staging buffer by the
+            // command encoder; map that and read back.
+            let staging = self.forest.staging_buffer.as_ref().unwrap();
+            let buffer_slice = staging.slice(..self.output_bytes);
+            buffer_slice.map_async(wgpu::MapMode::Read, |result| {
+                result.expect("GPU staging buffer mapping failed");
+            });
+            device
+                .poll(wgpu::PollType::Wait {
+                    submission_index: Some(self.submit_idx),
+                    timeout: Some(timeout),
+                })
+                .expect("GPU timed out during inference; consider increasing the timeout with GpuForest::with_collect_timeout");
+            let data = buffer_slice.get_mapped_range();
+            let result = Array1::from(bytemuck::cast_slice::<u8, f32>(&data).to_vec());
+            drop(data);
+            staging.unmap();
+            result
+        };
+
+        // Release the busy flag so predict_submit can be called again.
+        self.forest.busy.store(false, Ordering::Release);
+        result
+    }
+}
+
+/// A random forest loaded onto the GPU for batched inference.
+///
+/// Create with [`GpuForest::from_flat_forest`] (single forest) or
+/// [`GpuForest::with_context`] (multiple forests sharing a device), then call
+/// [`GpuForest::predict`].
+///
+/// Use [`GpuForest::fork`] to create per-thread handles that share compiled
+/// pipelines and uploaded node data without re-uploading or recompiling.
+/// Each handle has its own pre-allocated GPU inference buffers and is safe
+/// to use from a single thread concurrently with other handles forked from
+/// the same forest.
+pub struct GpuForest {
+    shared: Arc<GpuForestShared>,
+    /// Pre-allocated feature buffer.
+    /// UMA: `STORAGE | MAP_WRITE` — CPU writes directly via mapping.
+    /// Discrete: `STORAGE | COPY_DST` — written via `queue.write_buffer`.
+    /// Sized for `max_samples * n_features * 4` bytes.
+    feature_buffer: wgpu::Buffer,
+    /// Pre-allocated intermediate per-tree predictions (STORAGE).
+    /// Sized for `max_samples * n_trees * 4` bytes.
+    per_tree_preds_buffer: wgpu::Buffer,
+    /// Pre-allocated final per-sample means.
+    /// UMA: `STORAGE | MAP_READ` — CPU reads directly; no staging copy needed.
+    /// Discrete: `STORAGE | COPY_SRC` — copied to staging buffer before readback.
+    /// Sized for `max_samples * 4` bytes.
+    output_buffer: wgpu::Buffer,
+    /// CPU-readable staging buffer for discrete GPUs. `None` on UMA devices.
+    /// Discrete: `COPY_DST | MAP_READ`, sized for `max_samples * 4` bytes.
+    staging_buffer: Option<wgpu::Buffer>,
+    max_samples: usize,
+    /// Maximum time [`PredictHandle::collect`] will wait for the GPU.
+    /// Default: 10 seconds.
+    collect_timeout: Duration,
+    /// Set to `true` while a [`PredictHandle`] is outstanding. Guards against
+    /// calling [`predict_submit`] again before the previous handle is collected,
+    /// which would overwrite the feature buffer while the GPU may still read it.
+    ///
+    /// [`predict_submit`]: GpuForest::predict_submit
+    busy: AtomicBool,
+}
+
+impl GpuForest {
+    /// Upload a [`FlatForest`] to the GPU using a pre-initialised [`GpuContext`].
+    ///
+    /// Reuses the device, queue, and compiled compute pipelines from `ctx`,
+    /// avoiding redundant GPU initialisation and shader recompilation. Only the
+    /// per-forest node/meta buffers and per-instance inference buffers (sized for
+    /// `max_samples`) are newly allocated.
+    ///
+    /// This is the preferred constructor when serving multiple forests at
+    /// inference time.
+    ///
+    /// ```rust,no_run
+    /// # use biosphere::{FlatForest, RandomForest, RandomForestParameters};
+    /// # use biosphere::gpu::{GpuContext, GpuForest};
+    /// # use ndarray::Array2;
+    /// # let (flat_a, flat_b) = {
+    /// #     let make = |seed| {
+    /// #         let mut f = RandomForest::new(RandomForestParameters::default().with_seed(seed));
+    /// #         f.fit(&Array2::<f64>::zeros((2,1)).view(), &ndarray::Array1::zeros(2).view());
+    /// #         FlatForest::from_forest(&f, 1)
+    /// #     };
+    /// #     (make(1), make(2))
+    /// # };
+    /// let ctx = GpuContext::new().unwrap();
+    /// let forest_a = GpuForest::with_context(ctx.clone(), &flat_a, 1024);
+    /// let forest_b = GpuForest::with_context(ctx.clone(), &flat_b, 2048);
+    /// ```
+    pub fn with_context(ctx: Arc<GpuContext>, flat: &FlatForest, max_samples: usize) -> Self {
+        let device = &ctx.device;
+
+        // FlatNode is #[repr(C)] + bytemuck::Pod, so we can upload the node slice
+        // directly without any conversion.
+        let node_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("biosphere::gpu::nodes"),
+            contents: bytemuck::cast_slice::<FlatNode, u8>(&flat.nodes),
+            usage: wgpu::BufferUsages::STORAGE,
+        });
+
+        // ForestMeta is #[repr(C)] + bytemuck::Pod; upload directly.
+        let meta_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("biosphere::gpu::meta"),
+            contents: bytemuck::bytes_of(&flat.meta),
+            usage: wgpu::BufferUsages::STORAGE,
+        });
+
+        let shared = Arc::new(GpuForestShared {
+            ctx,
             node_buffer,
             meta_buffer,
             meta: flat.meta,
-            workgroup_size,
-            uma,
         });
 
-        Ok(Self::alloc_buffers(shared, max_samples))
+        Self::alloc_buffers(shared, max_samples)
+    }
+
+    /// Upload a [`FlatForest`] to the GPU and compile the compute pipelines.
+    ///
+    /// `max_samples` is the maximum batch size for a single [`predict`] call.
+    /// All GPU inference buffers are pre-allocated at this capacity, so
+    /// individual `predict` calls avoid any GPU memory allocation overhead.
+    ///
+    /// This convenience constructor initialises a private [`GpuContext`]
+    /// internally. When creating **multiple forests**, prefer [`GpuContext::new`]
+    /// once and then [`GpuForest::with_context`] for each forest so the device
+    /// and compiled pipelines are shared.
+    ///
+    /// On Apple Silicon and other unified-memory adapters, feature upload and
+    /// output readback use direct buffer mapping instead of staging copies,
+    /// eliminating redundant data movement within the shared memory pool.
+    ///
+    /// Node thresholds and leaf values are already `f32` in [`FlatForest`], so
+    /// no precision loss occurs during upload.
+    ///
+    /// [`predict`]: GpuForest::predict
+    pub fn from_flat_forest(
+        flat: &FlatForest,
+        max_samples: usize,
+    ) -> Result<Self, GpuInitError> {
+        let ctx = GpuContext::new()?;
+        Ok(Self::with_context(ctx, flat, max_samples))
     }
 
     /// Allocate the per-instance inference buffers for `max_samples` capacity.
     fn alloc_buffers(shared: Arc<GpuForestShared>, max_samples: usize) -> Self {
-        let device = &shared.device;
+        let device = &shared.ctx.device;
         let n_trees = shared.meta.n_trees as usize;
         let n_features = shared.meta.n_features as usize;
-        let uma = shared.uma;
+        let uma = shared.ctx.uma;
 
         let feature_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("biosphere::gpu::features"),
@@ -482,7 +574,7 @@ impl GpuForest {
     /// On UMA devices, feature upload and output readback use direct buffer
     /// mapping instead of staging copies, reducing memory bandwidth usage.
     pub fn is_uma(&self) -> bool {
-        self.shared.uma
+        self.shared.ctx.uma
     }
 
     /// Submit a batch inference job to the GPU and return a handle to collect results later.
@@ -534,15 +626,16 @@ impl GpuForest {
             .expect("standard layout is always contiguous");
 
         let shared = &self.shared;
-        let device = &shared.device;
-        let queue = &shared.queue;
+        let ctx = &shared.ctx;
+        let device = &ctx.device;
+        let queue = &ctx.queue;
         let n_trees = shared.meta.n_trees as usize;
 
         let feature_bytes = (n_samples * n_features * size_of::<f32>()) as u64;
         let per_tree_bytes = (n_samples * n_trees * size_of::<f32>()) as u64;
         let output_bytes = (n_samples * size_of::<f32>()) as u64;
 
-        if shared.uma {
+        if ctx.uma {
             // UMA path: map feature_buffer directly and write without a staging blit.
             // The buffer is guaranteed to be free here (enforced by the busy flag above).
             // Use a bounded 1-second timeout to detect wgpu validation errors that would
@@ -573,7 +666,7 @@ impl GpuForest {
         // the actual n_samples, not the full max_samples capacity.
         let traverse_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: None,
-            layout: &shared.traverse_bgl,
+            layout: &ctx.traverse_bgl,
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,
@@ -604,7 +697,7 @@ impl GpuForest {
 
         let reduce_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: None,
-            layout: &shared.reduce_bgl,
+            layout: &ctx.reduce_bgl,
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,
@@ -633,9 +726,9 @@ impl GpuForest {
                 label: Some("biosphere::gpu::traverse_pass"),
                 timestamp_writes: None,
             });
-            cpass.set_pipeline(&shared.traverse_pipeline);
+            cpass.set_pipeline(&ctx.traverse_pipeline);
             cpass.set_bind_group(0, &traverse_bg, &[]);
-            let x_groups = n_samples.div_ceil(shared.workgroup_size as usize) as u32;
+            let x_groups = n_samples.div_ceil(ctx.workgroup_size as usize) as u32;
             cpass.dispatch_workgroups(x_groups, shared.meta.n_trees, 1);
         }
 
@@ -644,13 +737,13 @@ impl GpuForest {
                 label: Some("biosphere::gpu::reduce_pass"),
                 timestamp_writes: None,
             });
-            cpass.set_pipeline(&shared.reduce_pipeline);
+            cpass.set_pipeline(&ctx.reduce_pipeline);
             cpass.set_bind_group(0, &reduce_bg, &[]);
-            let x_groups = n_samples.div_ceil(shared.workgroup_size as usize) as u32;
+            let x_groups = n_samples.div_ceil(ctx.workgroup_size as usize) as u32;
             cpass.dispatch_workgroups(x_groups, 1, 1);
         }
 
-        if !shared.uma {
+        if !ctx.uma {
             // Discrete GPU: copy output to the staging buffer so the CPU can read it.
             encoder.copy_buffer_to_buffer(
                 &self.output_buffer,
@@ -689,7 +782,9 @@ impl GpuForest {
     }
 }
 
-// --- Helpers ---
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 fn storage_ro_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
     wgpu::BindGroupLayoutEntry {

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -270,6 +270,9 @@ impl GpuForest {
 
     /// Run batched inference on `n_samples` samples.
     ///
+    /// See [`GpuForest::predict_async`] for the async version that avoids
+    /// blocking the current thread.
+    ///
     /// `features` is a row-major f32 slice of shape `(n_samples, n_features)`.
     /// Returns one f32 prediction per sample (mean of all tree predictions).
     ///
@@ -280,15 +283,28 @@ impl GpuForest {
         if n_samples == 0 {
             return vec![];
         }
+        pollster::block_on(self.predict_async(features, n_samples))
+    }
+
+    /// Async batched inference on `n_samples` samples. Use this if you need to
+    /// await other async work between GPU submission and result retrieval.
+    ///
+    /// `features` is a row-major f32 slice of shape `(n_samples, n_features)`.
+    /// Returns one f32 prediction per sample (mean of all tree predictions).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n_samples > max_samples` (the value passed to [`from_flat_forest`]).
+    pub async fn predict_async(&self, features: &[f32], n_samples: usize) -> Vec<f32> {
+        if n_samples == 0 {
+            return vec![];
+        }
         assert!(
             n_samples <= self.max_samples,
             "n_samples={n_samples} exceeds max_samples={}",
             self.max_samples
         );
-        pollster::block_on(self.predict_async(features, n_samples))
-    }
 
-    async fn predict_async(&self, features: &[f32], n_samples: usize) -> Vec<f32> {
         let shared = &self.shared;
         let device = &shared.device;
         let queue = &shared.queue;

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -7,6 +7,41 @@ use std::time::Duration;
 use wgpu::util::DeviceExt;
 
 // ---------------------------------------------------------------------------
+// GpuInferenceError
+// ---------------------------------------------------------------------------
+
+/// Error returned by [`GpuForest::predict`], [`GpuForest::predict_submit`], and
+/// [`PredictHandle::collect`] when a runtime GPU inference operation fails.
+///
+/// This is distinct from [`GpuInitError`], which covers GPU initialisation
+/// failures (adapter selection, device creation, pipeline compilation). Inference
+/// errors occur after the GPU is successfully initialised and reflect problems
+/// that arise during batched prediction, such as the GPU not completing within
+/// the configured timeout.
+#[derive(Debug)]
+pub enum GpuInferenceError {
+    /// The GPU did not complete within the configured timeout.
+    Timeout {
+        /// Which step timed out (e.g. "inference (UMA output readback)").
+        step: &'static str,
+        /// The timeout that was exceeded.
+        timeout: Duration,
+    },
+}
+
+impl fmt::Display for GpuInferenceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Timeout { step, timeout } => {
+                write!(f, "GPU timed out during {step} after {timeout:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GpuInferenceError {}
+
+// ---------------------------------------------------------------------------
 // GpuInitError
 // ---------------------------------------------------------------------------
 
@@ -16,38 +51,42 @@ use wgpu::util::DeviceExt;
 /// most common causes of GPU initialization failures in headless / HPC / SLURM
 /// environments.
 #[derive(Debug)]
-pub struct GpuInitError {
-    message: String,
-    source: Option<wgpu::RequestDeviceError>,
+pub enum GpuInitError {
+    /// No suitable GPU adapter was found.
+    ///
+    /// In headless / HPC / SLURM environments this typically means the Vulkan
+    /// ICD is not linked to the allocated GPU.
+    NoAdapter,
+
+    /// The GPU device could not be created.
+    ///
+    /// When `limits_exceeded` is `true`, the adapter reported zero capacity for
+    /// a required compute limit, which usually means wgpu fell back to a
+    /// software rasteriser or stub driver with no real compute support.
+    DeviceCreation {
+        source: Box<wgpu::RequestDeviceError>,
+        /// `true` when the Debug representation of the underlying error
+        /// contains `"allowed: 0"` or `"LimitsExceeded"`, indicating the
+        /// adapter lacks real compute support.
+        limits_exceeded: bool,
+    },
 }
 
 impl GpuInitError {
-    fn no_adapter() -> Self {
-        Self {
-            message: "no suitable GPU adapter found; in headless / HPC / SLURM environments \
-                      this typically means the Vulkan ICD is not linked to the allocated GPU"
-                .to_owned(),
-            source: None,
-        }
-    }
-
     fn device_creation(e: wgpu::RequestDeviceError) -> Self {
-        // `allowed: 0` for a compute limit means wgpu found no real GPU adapter
-        // with compute support — the Vulkan ICD is not wired up to the allocated
-        // device (common in headless / HPC / SLURM jobs).
+        // wgpu 28 does not expose structured error variants for
+        // `RequestDeviceError`; the only way to distinguish a "no real adapter
+        // with compute support" failure from other device-creation errors is to
+        // inspect the Debug representation. The strings `"allowed: 0"` and
+        // `"LimitsExceeded"` were verified against wgpu 28 and reflect how it
+        // formats limit-exceeded errors internally. If wgpu changes its internal
+        // formatting in a future release this heuristic may need updating.
+        // TODO: switch to structured matching when wgpu exposes error variants.
         let dbg = format!("{e:?}");
-        let message = if dbg.contains("allowed: 0") || dbg.contains("LimitsExceeded") {
-            format!(
-                "GPU device creation failed ({e}); `allowed: 0` for a compute limit \
-                 indicates wgpu found no real adapter with compute support — the Vulkan \
-                 ICD is likely not linked to the allocated device"
-            )
-        } else {
-            format!("GPU device creation failed: {e}")
-        };
-        Self {
-            message,
-            source: Some(e),
+        let limits_exceeded = dbg.contains("allowed: 0") || dbg.contains("LimitsExceeded");
+        Self::DeviceCreation {
+            source: Box::new(e),
+            limits_exceeded,
         }
     }
 
@@ -71,13 +110,34 @@ impl GpuInitError {
 
 impl fmt::Display for GpuInitError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.message)
+        match self {
+            Self::NoAdapter => f.write_str(
+                "no suitable GPU adapter found; in headless / HPC / SLURM environments \
+                 this typically means the Vulkan ICD is not linked to the allocated GPU",
+            ),
+            Self::DeviceCreation {
+                source,
+                limits_exceeded: true,
+            } => write!(
+                f,
+                "GPU device creation failed ({source}); `allowed: 0` for a compute limit \
+                 indicates wgpu found no real adapter with compute support — the Vulkan \
+                 ICD is likely not linked to the allocated device",
+            ),
+            Self::DeviceCreation {
+                source,
+                limits_exceeded: false,
+            } => write!(f, "GPU device creation failed: {source}"),
+        }
     }
 }
 
 impl std::error::Error for GpuInitError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.source.as_ref().map(|e| e as _)
+        match self {
+            Self::NoAdapter => None,
+            Self::DeviceCreation { source, .. } => Some(source),
+        }
     }
 }
 
@@ -136,7 +196,7 @@ impl GpuContext {
                 force_fallback_adapter: false,
             })
             .await
-            .map_err(|_| GpuInitError::no_adapter())?;
+            .map_err(|_| GpuInitError::NoAdapter)?;
 
         // On unified-memory adapters (Apple Silicon, Vulkan/DX12 UMA) the
         // MAPPABLE_PRIMARY_BUFFERS feature lets us combine STORAGE with MAP_READ
@@ -294,9 +354,12 @@ impl<'forest> PredictHandle<'forest> {
     ///
     /// One `f32` per sample, in the same order as the input to [`GpuForest::predict_submit`].
     ///
-    /// Panics if the GPU does not complete within the timeout configured via
-    /// [`GpuForest::with_collect_timeout`] (default: 10 seconds).
-    pub fn collect(self) -> Array1<f32> {
+    /// # Errors
+    ///
+    /// Returns [`GpuInferenceError`] if the GPU does not complete within the
+    /// timeout configured via [`GpuForest::with_collect_timeout`] (default: 10
+    /// seconds). Increase the timeout for very large forests or slow adapters.
+    pub fn collect(self) -> Result<Array1<f32>, GpuInferenceError> {
         let device = &self.forest.shared.ctx.device;
         let timeout = self.forest.collect_timeout;
 
@@ -312,7 +375,10 @@ impl<'forest> PredictHandle<'forest> {
                     submission_index: Some(self.submit_idx),
                     timeout: Some(timeout),
                 })
-                .expect("GPU timed out during inference; consider increasing the timeout with GpuForest::with_collect_timeout");
+                .map_err(|_| GpuInferenceError::Timeout {
+                    step: "inference (UMA output readback)",
+                    timeout,
+                })?;
             let data = slice.get_mapped_range();
             let result = Array1::from(bytemuck::cast_slice::<u8, f32>(&data).to_vec());
             drop(data);
@@ -331,7 +397,10 @@ impl<'forest> PredictHandle<'forest> {
                     submission_index: Some(self.submit_idx),
                     timeout: Some(timeout),
                 })
-                .expect("GPU timed out during inference; consider increasing the timeout with GpuForest::with_collect_timeout");
+                .map_err(|_| GpuInferenceError::Timeout {
+                    step: "inference (discrete GPU output readback)",
+                    timeout,
+                })?;
             let data = buffer_slice.get_mapped_range();
             let result = Array1::from(bytemuck::cast_slice::<u8, f32>(&data).to_vec());
             drop(data);
@@ -341,7 +410,7 @@ impl<'forest> PredictHandle<'forest> {
 
         // Release the busy flag so predict_submit can be called again.
         self.forest.busy.store(false, Ordering::Release);
-        result
+        Ok(result)
     }
 }
 
@@ -396,6 +465,14 @@ impl GpuForest {
     ///
     /// This is the preferred constructor when serving multiple forests at
     /// inference time.
+    ///
+    /// # Panics
+    ///
+    /// Buffer allocation failures (e.g. GPU out-of-memory) result in a panic
+    /// from the underlying wgpu backend rather than a returned error; GPU OOM
+    /// will terminate the process. This matches the behaviour of `wgpu::Device::create_buffer`,
+    /// which panics internally on OOM in current wgpu rather than returning a `Result`.
+    /// For this reason `with_context` returns `Self` rather than `Result<Self, …>`.
     ///
     /// ```rust,no_run
     /// # use biosphere::{FlatForest, RandomForest, RandomForestParameters};
@@ -467,6 +544,11 @@ impl GpuForest {
 
     /// Allocate the per-instance inference buffers for `max_samples` capacity.
     fn alloc_buffers(shared: Arc<GpuForestShared>, max_samples: usize) -> Self {
+        assert!(
+            max_samples > 0,
+            "max_samples must be at least 1; use GpuForest::predict for batches and handle \
+             empty input at the call site"
+        );
         let device = &shared.ctx.device;
         let n_trees = shared.meta.n_trees as usize;
         let n_features = shared.meta.n_features as usize;
@@ -583,10 +665,15 @@ impl GpuForest {
     /// to wait for completion and retrieve predictions. Submitting multiple handles before
     /// collecting any allows the GPU to execute the work concurrently.
     ///
-    /// Returns `None` when `X` has zero rows.
+    /// Returns `Ok(None)` when `X` has zero rows.
     ///
     /// `X` is a 2-D array of shape `(n_samples, n_features)`. If `X` is not
     /// already in C (row-major) contiguous order it will be copied before upload.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GpuInferenceError`] if the UMA feature-buffer mapping poll times
+    /// out (controlled by [`GpuForest::with_collect_timeout`]; default 10 s).
     ///
     /// # Panics
     ///
@@ -594,10 +681,13 @@ impl GpuForest {
     /// - If `X.ncols() != n_features`.
     /// - If called while a previously returned [`PredictHandle`] has not yet been collected
     ///   (would overwrite the feature buffer while the GPU is still reading it).
-    pub fn predict_submit(&self, X: &ArrayView2<f32>) -> Option<PredictHandle<'_>> {
+    pub fn predict_submit(
+        &self,
+        X: &ArrayView2<f32>,
+    ) -> Result<Option<PredictHandle<'_>>, GpuInferenceError> {
         let n_samples = X.nrows();
         if n_samples == 0 {
-            return None;
+            return Ok(None);
         }
 
         assert!(
@@ -638,8 +728,9 @@ impl GpuForest {
         if ctx.uma {
             // UMA path: map feature_buffer directly and write without a staging blit.
             // The buffer is guaranteed to be free here (enforced by the busy flag above).
-            // Use a bounded 1-second timeout to detect wgpu validation errors that would
-            // otherwise block forever.
+            // Use collect_timeout (not a hardcoded value) to detect wgpu validation errors
+            // that would otherwise block forever, while still respecting the caller's
+            // configured latency budget.
             let slice = self.feature_buffer.slice(..feature_bytes);
             slice.map_async(wgpu::MapMode::Write, |r| {
                 r.expect("feature buffer map failed");
@@ -647,12 +738,12 @@ impl GpuForest {
             device
                 .poll(wgpu::PollType::Wait {
                     submission_index: None,
-                    timeout: Some(Duration::from_secs(1)),
+                    timeout: Some(self.collect_timeout),
                 })
-                .expect(
-                    "GPU timed out waiting for UMA feature buffer to become available; \
-                     a wgpu validation error may have occurred",
-                );
+                .map_err(|_| GpuInferenceError::Timeout {
+                    step: "UMA feature buffer mapping (a wgpu validation error may have occurred)",
+                    timeout: self.collect_timeout,
+                })?;
             {
                 let mut mapped = slice.get_mapped_range_mut();
                 mapped.copy_from_slice(bytemuck::cast_slice(features));
@@ -756,29 +847,35 @@ impl GpuForest {
 
         let submit_idx = queue.submit(Some(encoder.finish()));
 
-        Some(PredictHandle {
+        Ok(Some(PredictHandle {
             forest: self,
             submit_idx,
             output_bytes,
-        })
+        }))
     }
 
     /// Run batched inference on `n_samples` samples, blocking until complete.
     ///
-    /// Equivalent to `predict_submit(X).map(|h| h.collect()).unwrap_or_default()`.
+    /// Equivalent to calling `predict_submit(X)` then `collect()` on the handle.
     /// Use [`GpuForest::predict_submit`] with deferred [`PredictHandle::collect`] to overlap
     /// GPU work across multiple forests.
     ///
     /// `X` is a 2-D array of shape `(n_samples, n_features)`.
     /// Returns one f32 prediction per sample (mean of all tree predictions).
     ///
+    /// # Errors
+    ///
+    /// Returns [`GpuInferenceError`] if the GPU times out. See
+    /// [`GpuForest::with_collect_timeout`] to adjust the limit (default: 10 s).
+    ///
     /// # Panics
     ///
     /// Panics if `X.nrows() > max_samples` (the value passed to [`GpuForest::from_flat_forest`]).
-    pub fn predict(&self, X: &ArrayView2<f32>) -> Array1<f32> {
-        self.predict_submit(X)
-            .map(|h| h.collect())
-            .unwrap_or_else(|| Array1::zeros(0))
+    pub fn predict(&self, X: &ArrayView2<f32>) -> Result<Array1<f32>, GpuInferenceError> {
+        match self.predict_submit(X)? {
+            Some(handle) => handle.collect(),
+            None => Ok(Array1::zeros(0)),
+        }
     }
 }
 

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -46,6 +46,41 @@ struct GpuForestShared {
     n_features: u32,
 }
 
+/// A submitted GPU inference job awaiting results.
+///
+/// Created by [`GpuForest::predict_submit`]. Call [`PredictHandle::collect`] to
+/// wait for the GPU to finish and retrieve the predictions.
+///
+/// Submitting multiple handles before calling `collect` on any of them lets the
+/// GPU execute the underlying work concurrently.
+pub struct PredictHandle<'forest> {
+    forest: &'forest GpuForest,
+    submit_idx: wgpu::SubmissionIndex,
+    output_bytes: u64,
+}
+
+impl<'forest> PredictHandle<'forest> {
+    /// Block until the GPU finishes this submission and return the predictions.
+    ///
+    /// One `f32` per sample, in the same order as the input to [`GpuForest::predict_submit`].
+    pub fn collect(self) -> Vec<f32> {
+        let device = &self.forest.shared.device;
+        let buffer_slice = self.forest.staging_buffer.slice(..self.output_bytes);
+        buffer_slice.map_async(wgpu::MapMode::Read, |_| {});
+        device
+            .poll(wgpu::PollType::Wait {
+                submission_index: Some(self.submit_idx),
+                timeout: Some(std::time::Duration::from_secs(10)),
+            })
+            .expect("GPU poll failed");
+        let data = buffer_slice.get_mapped_range();
+        let result = bytemuck::cast_slice::<u8, f32>(&data).to_vec();
+        drop(data);
+        self.forest.staging_buffer.unmap();
+        result
+    }
+}
+
 /// A random forest loaded onto the GPU for batched inference.
 ///
 /// Create with [`GpuForest::from_flat_forest`], then call [`GpuForest::predict`].
@@ -268,20 +303,22 @@ impl GpuForest {
         Self::alloc_buffers(Arc::clone(&self.shared), max_samples)
     }
 
-    /// Run batched inference on `n_samples` samples.
+    /// Submit a batch inference job to the GPU and return a handle to collect results later.
     ///
-    /// See [`GpuForest::predict_async`] for the async version that avoids
-    /// blocking the current thread.
+    /// The GPU begins work immediately. Call [`PredictHandle::collect`] on the returned handle
+    /// to wait for completion and retrieve predictions. Submitting multiple handles before
+    /// collecting any allows the GPU to execute the work concurrently.
+    ///
+    /// Returns `None` when `n_samples == 0`.
     ///
     /// `features` is a row-major f32 slice of shape `(n_samples, n_features)`.
-    /// Returns one f32 prediction per sample (mean of all tree predictions).
     ///
     /// # Panics
     ///
     /// Panics if `n_samples > max_samples` (the value passed to [`GpuForest::from_flat_forest`]).
-    pub fn predict(&self, features: &[f32], n_samples: usize) -> Vec<f32> {
+    pub fn predict_submit(&self, features: &[f32], n_samples: usize) -> Option<PredictHandle<'_>> {
         if n_samples == 0 {
-            return vec![];
+            return None;
         }
         assert!(
             n_samples <= self.max_samples,
@@ -299,11 +336,10 @@ impl GpuForest {
         let per_tree_bytes = (n_samples * n_trees * size_of::<f32>()) as u64;
         let output_bytes = (n_samples * size_of::<f32>()) as u64;
 
-        // Upload features into the pre-allocated buffer.
         queue.write_buffer(&self.feature_buffer, 0, bytemuck::cast_slice(features));
 
-        // Create bind groups with sub-range sizes so that arrayLength() in the
-        // shaders reflects the actual n_samples, not the full max_samples capacity.
+        // Sub-range bind groups so that arrayLength() in the shaders reflects
+        // the actual n_samples, not the full max_samples capacity.
         let traverse_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: None,
             layout: &shared.traverse_bgl,
@@ -358,7 +394,6 @@ impl GpuForest {
             ],
         });
 
-        // --- Encode and submit ---
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
 
@@ -393,23 +428,29 @@ impl GpuForest {
         );
         let submit_idx = queue.submit(Some(encoder.finish()));
 
-        // --- Read results ---
-        // Map only the used portion of the pre-allocated staging buffer.
-        let buffer_slice = self.staging_buffer.slice(..output_bytes);
-        buffer_slice.map_async(wgpu::MapMode::Read, |_| {});
-        // Wait for exactly our submission — safe even with a shared device/queue.
-        device
-            .poll(wgpu::PollType::Wait {
-                submission_index: Some(submit_idx),
-                timeout: Some(std::time::Duration::from_secs(10)),
-            })
-            .expect("GPU poll failed");
+        Some(PredictHandle {
+            forest: self,
+            submit_idx,
+            output_bytes,
+        })
+    }
 
-        let data = buffer_slice.get_mapped_range();
-        let result = bytemuck::cast_slice::<u8, f32>(&data).to_vec();
-        drop(data);
-        self.staging_buffer.unmap();
-        result
+    /// Run batched inference on `n_samples` samples, blocking until complete.
+    ///
+    /// Equivalent to `predict_submit(features, n_samples).map(|h| h.collect()).unwrap_or_default()`.
+    /// Use [`GpuForest::predict_submit`] with deferred [`PredictHandle::collect`] to overlap
+    /// GPU work across multiple forests.
+    ///
+    /// `features` is a row-major f32 slice of shape `(n_samples, n_features)`.
+    /// Returns one f32 prediction per sample (mean of all tree predictions).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n_samples > max_samples` (the value passed to [`GpuForest::from_flat_forest`]).
+    pub fn predict(&self, features: &[f32], n_samples: usize) -> Vec<f32> {
+        self.predict_submit(features, n_samples)
+            .map(|h| h.collect())
+            .unwrap_or_default()
     }
 }
 

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -1,4 +1,5 @@
 use crate::flat_forest::{FlatForest, FlatNode, ForestMeta};
+use ndarray::{Array1, ArrayView2};
 use std::sync::Arc;
 use wgpu::util::DeviceExt;
 
@@ -21,6 +22,11 @@ struct GpuForestShared {
     meta: ForestMeta,
     /// Workgroup size chosen from device limits at pipeline-compile time.
     workgroup_size: u32,
+    /// True when the adapter supports `MAPPABLE_PRIMARY_BUFFERS` (Apple Silicon,
+    /// Vulkan UMA, DX12 UMA). On these devices the CPU and GPU share the same
+    /// physical memory, so feature upload and output readback can use direct
+    /// buffer mapping instead of staging copies.
+    uma: bool,
 }
 
 /// A submitted GPU inference job awaiting results.
@@ -40,23 +46,47 @@ impl<'forest> PredictHandle<'forest> {
     /// Block until the GPU finishes this submission and return the predictions.
     ///
     /// One `f32` per sample, in the same order as the input to [`GpuForest::predict_submit`].
-    pub fn collect(self) -> Vec<f32> {
+    pub fn collect(self) -> Array1<f32> {
         let device = &self.forest.shared.device;
-        let buffer_slice = self.forest.staging_buffer.slice(..self.output_bytes);
-        buffer_slice.map_async(wgpu::MapMode::Read, |result| {
-            result.expect("GPU staging buffer mapping failed");
-        });
-        device
-            .poll(wgpu::PollType::Wait {
-                submission_index: Some(self.submit_idx),
-                timeout: Some(std::time::Duration::from_secs(10)),
-            })
-            .expect("GPU poll failed");
-        let data = buffer_slice.get_mapped_range();
-        let result = bytemuck::cast_slice::<u8, f32>(&data).to_vec();
-        drop(data);
-        self.forest.staging_buffer.unmap();
-        result
+
+        if self.forest.shared.uma {
+            // UMA path: output_buffer has MAP_READ usage, so we read directly
+            // without a staging copy. The poll also waits for the GPU submission.
+            let slice = self.forest.output_buffer.slice(..self.output_bytes);
+            slice.map_async(wgpu::MapMode::Read, |r| {
+                r.expect("GPU output buffer mapping failed");
+            });
+            device
+                .poll(wgpu::PollType::Wait {
+                    submission_index: Some(self.submit_idx),
+                    timeout: Some(std::time::Duration::from_secs(10)),
+                })
+                .expect("GPU poll failed");
+            let data = slice.get_mapped_range();
+            let result = Array1::from(bytemuck::cast_slice::<u8, f32>(&data).to_vec());
+            drop(data);
+            self.forest.output_buffer.unmap();
+            result
+        } else {
+            // Discrete GPU path: results were copied to the staging buffer by the
+            // command encoder; map that and read back.
+            let staging = self.forest.staging_buffer.as_ref().unwrap();
+            let buffer_slice = staging.slice(..self.output_bytes);
+            buffer_slice.map_async(wgpu::MapMode::Read, |result| {
+                result.expect("GPU staging buffer mapping failed");
+            });
+            device
+                .poll(wgpu::PollType::Wait {
+                    submission_index: Some(self.submit_idx),
+                    timeout: Some(std::time::Duration::from_secs(10)),
+                })
+                .expect("GPU poll failed");
+            let data = buffer_slice.get_mapped_range();
+            let result = Array1::from(bytemuck::cast_slice::<u8, f32>(&data).to_vec());
+            drop(data);
+            staging.unmap();
+            result
+        }
     }
 }
 
@@ -71,18 +101,22 @@ impl<'forest> PredictHandle<'forest> {
 /// the same forest.
 pub struct GpuForest {
     shared: Arc<GpuForestShared>,
-    /// Pre-allocated feature upload buffer (STORAGE | COPY_DST).
+    /// Pre-allocated feature buffer.
+    /// UMA: `STORAGE | MAP_WRITE` — CPU writes directly via mapping.
+    /// Discrete: `STORAGE | COPY_DST` — written via `queue.write_buffer`.
     /// Sized for `max_samples * n_features * 4` bytes.
     feature_buffer: wgpu::Buffer,
     /// Pre-allocated intermediate per-tree predictions (STORAGE).
     /// Sized for `max_samples * n_trees * 4` bytes.
     per_tree_preds_buffer: wgpu::Buffer,
-    /// Pre-allocated final per-sample means (STORAGE | COPY_SRC).
+    /// Pre-allocated final per-sample means.
+    /// UMA: `STORAGE | MAP_READ` — CPU reads directly; no staging copy needed.
+    /// Discrete: `STORAGE | COPY_SRC` — copied to staging buffer before readback.
     /// Sized for `max_samples * 4` bytes.
     output_buffer: wgpu::Buffer,
-    /// Pre-allocated CPU-readable staging buffer (COPY_DST | MAP_READ).
-    /// Sized for `max_samples * 4` bytes.
-    staging_buffer: wgpu::Buffer,
+    /// CPU-readable staging buffer for discrete GPUs. `None` on UMA devices.
+    /// Discrete: `COPY_DST | MAP_READ`, sized for `max_samples * 4` bytes.
+    staging_buffer: Option<wgpu::Buffer>,
     max_samples: usize,
 }
 
@@ -92,6 +126,10 @@ impl GpuForest {
     /// `max_samples` is the maximum batch size for a single [`predict`] call.
     /// All GPU inference buffers are pre-allocated at this capacity, so individual
     /// `predict` calls avoid any GPU memory allocation overhead.
+    ///
+    /// On Apple Silicon and other unified-memory adapters, feature upload and
+    /// output readback use direct buffer mapping instead of staging copies,
+    /// eliminating redundant data movement within the shared memory pool.
     ///
     /// Node thresholds and leaf values are already `f32` in [`FlatForest`], so
     /// no precision loss occurs during upload.
@@ -113,8 +151,23 @@ impl GpuForest {
             .await
             .expect("No suitable GPU adapter found");
 
+        // On unified-memory adapters (Apple Silicon, Vulkan/DX12 UMA) the
+        // MAPPABLE_PRIMARY_BUFFERS feature lets us combine STORAGE with MAP_READ
+        // / MAP_WRITE. This maps to MTLStorageModeShared on Metal, allowing
+        // direct CPU↔GPU access with no staging blit.
+        let uma = adapter
+            .features()
+            .contains(wgpu::Features::MAPPABLE_PRIMARY_BUFFERS);
+
         let (device, queue) = adapter
-            .request_device(&wgpu::DeviceDescriptor::default())
+            .request_device(&wgpu::DeviceDescriptor {
+                required_features: if uma {
+                    wgpu::Features::MAPPABLE_PRIMARY_BUFFERS
+                } else {
+                    wgpu::Features::empty()
+                },
+                ..Default::default()
+            })
             .await
             .expect("Failed to create GPU device");
 
@@ -220,6 +273,7 @@ impl GpuForest {
             meta_buffer,
             meta: flat.meta,
             workgroup_size,
+            uma,
         });
 
         Self::alloc_buffers(shared, max_samples)
@@ -230,11 +284,18 @@ impl GpuForest {
         let device = &shared.device;
         let n_trees = shared.meta.n_trees as usize;
         let n_features = shared.meta.n_features as usize;
+        let uma = shared.uma;
 
         let feature_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("biosphere::gpu::features"),
             size: (max_samples * n_features * size_of::<f32>()) as u64,
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            usage: if uma {
+                // MAP_WRITE: CPU can write directly; Metal allocates as
+                // MTLStorageModeShared, so no staging blit is needed.
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::MAP_WRITE
+            } else {
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST
+            },
             mapped_at_creation: false,
         });
 
@@ -248,16 +309,26 @@ impl GpuForest {
         let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("biosphere::gpu::output"),
             size: (max_samples * size_of::<f32>()) as u64,
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            usage: if uma {
+                // MAP_READ: CPU can read directly from the same physical memory
+                // the GPU wrote to; no copy_buffer_to_buffer needed.
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::MAP_READ
+            } else {
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC
+            },
             mapped_at_creation: false,
         });
 
-        let staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("biosphere::gpu::staging"),
-            size: (max_samples * size_of::<f32>()) as u64,
-            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
-            mapped_at_creation: false,
-        });
+        let staging_buffer = if uma {
+            None
+        } else {
+            Some(device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("biosphere::gpu::staging"),
+                size: (max_samples * size_of::<f32>()) as u64,
+                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+                mapped_at_creation: false,
+            }))
+        };
 
         GpuForest {
             shared,
@@ -288,14 +359,17 @@ impl GpuForest {
     /// to wait for completion and retrieve predictions. Submitting multiple handles before
     /// collecting any allows the GPU to execute the work concurrently.
     ///
-    /// Returns `None` when `n_samples == 0`.
+    /// Returns `None` when `X` has zero rows.
     ///
-    /// `features` is a row-major f32 slice of shape `(n_samples, n_features)`.
+    /// `X` is a 2-D array of shape `(n_samples, n_features)`. If `X` is not
+    /// already in C (row-major) contiguous order it will be copied before upload.
     ///
     /// # Panics
     ///
-    /// Panics if `n_samples > max_samples` (the value passed to [`GpuForest::from_flat_forest`]).
-    pub fn predict_submit(&self, features: &[f32], n_samples: usize) -> Option<PredictHandle<'_>> {
+    /// Panics if `X.nrows() > max_samples` (the value passed to [`GpuForest::from_flat_forest`])
+    /// or if `X.ncols() != n_features`.
+    pub fn predict_submit(&self, X: &ArrayView2<f32>) -> Option<PredictHandle<'_>> {
+        let n_samples = X.nrows();
         if n_samples == 0 {
             return None;
         }
@@ -304,18 +378,50 @@ impl GpuForest {
             "n_samples={n_samples} exceeds max_samples={}",
             self.max_samples
         );
+        let n_features = self.shared.meta.n_features as usize;
+        assert_eq!(
+            X.ncols(),
+            n_features,
+            "X.ncols()={} must equal n_features={n_features}",
+            X.ncols(),
+        );
+
+        // Ensure row-major contiguous layout (zero-copy if already standard layout).
+        let X_c = X.as_standard_layout();
+        let features = X_c.as_slice().expect("standard layout is always contiguous");
 
         let shared = &self.shared;
         let device = &shared.device;
         let queue = &shared.queue;
-        let n_features = shared.meta.n_features as usize;
         let n_trees = shared.meta.n_trees as usize;
 
         let feature_bytes = (n_samples * n_features * size_of::<f32>()) as u64;
         let per_tree_bytes = (n_samples * n_trees * size_of::<f32>()) as u64;
         let output_bytes = (n_samples * size_of::<f32>()) as u64;
 
-        queue.write_buffer(&self.feature_buffer, 0, bytemuck::cast_slice(features));
+        if shared.uma {
+            // UMA path: map feature_buffer directly and write without a staging blit.
+            // The buffer is guaranteed to be free here — the caller must have collected
+            // (or never started) the previous PredictHandle before calling predict_submit
+            // again on the same GpuForest. The poll should return immediately.
+            let slice = self.feature_buffer.slice(..feature_bytes);
+            slice.map_async(wgpu::MapMode::Write, |r| {
+                r.expect("feature buffer map failed");
+            });
+            device
+                .poll(wgpu::PollType::Wait {
+                    submission_index: None,
+                    timeout: None,
+                })
+                .expect("GPU poll for feature buffer map failed");
+            {
+                let mut mapped = slice.get_mapped_range_mut();
+                mapped.copy_from_slice(bytemuck::cast_slice(features));
+            }
+            self.feature_buffer.unmap();
+        } else {
+            queue.write_buffer(&self.feature_buffer, 0, bytemuck::cast_slice(features));
+        }
 
         // Sub-range bind groups so that arrayLength() in the shaders reflects
         // the actual n_samples, not the full max_samples capacity.
@@ -398,13 +504,17 @@ impl GpuForest {
             cpass.dispatch_workgroups(x_groups, 1, 1);
         }
 
-        encoder.copy_buffer_to_buffer(
-            &self.output_buffer,
-            0,
-            &self.staging_buffer,
-            0,
-            output_bytes,
-        );
+        if !shared.uma {
+            // Discrete GPU: copy output to the staging buffer so the CPU can read it.
+            encoder.copy_buffer_to_buffer(
+                &self.output_buffer,
+                0,
+                self.staging_buffer.as_ref().unwrap(),
+                0,
+                output_bytes,
+            );
+        }
+
         let submit_idx = queue.submit(Some(encoder.finish()));
 
         Some(PredictHandle {
@@ -416,20 +526,20 @@ impl GpuForest {
 
     /// Run batched inference on `n_samples` samples, blocking until complete.
     ///
-    /// Equivalent to `predict_submit(features, n_samples).map(|h| h.collect()).unwrap_or_default()`.
+    /// Equivalent to `predict_submit(X).map(|h| h.collect()).unwrap_or_default()`.
     /// Use [`GpuForest::predict_submit`] with deferred [`PredictHandle::collect`] to overlap
     /// GPU work across multiple forests.
     ///
-    /// `features` is a row-major f32 slice of shape `(n_samples, n_features)`.
+    /// `X` is a 2-D array of shape `(n_samples, n_features)`.
     /// Returns one f32 prediction per sample (mean of all tree predictions).
     ///
     /// # Panics
     ///
-    /// Panics if `n_samples > max_samples` (the value passed to [`GpuForest::from_flat_forest`]).
-    pub fn predict(&self, features: &[f32], n_samples: usize) -> Vec<f32> {
-        self.predict_submit(features, n_samples)
+    /// Panics if `X.nrows() > max_samples` (the value passed to [`GpuForest::from_flat_forest`]).
+    pub fn predict(&self, X: &ArrayView2<f32>) -> Array1<f32> {
+        self.predict_submit(X)
             .map(|h| h.collect())
-            .unwrap_or_default()
+            .unwrap_or_else(|| Array1::zeros(0))
     }
 }
 

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -66,7 +66,9 @@ impl<'forest> PredictHandle<'forest> {
     pub fn collect(self) -> Vec<f32> {
         let device = &self.forest.shared.device;
         let buffer_slice = self.forest.staging_buffer.slice(..self.output_bytes);
-        buffer_slice.map_async(wgpu::MapMode::Read, |_| {});
+        buffer_slice.map_async(wgpu::MapMode::Read, |result| {
+            result.expect("GPU staging buffer mapping failed");
+        });
         device
             .poll(wgpu::PollType::Wait {
                 submission_index: Some(self.submit_idx),
@@ -146,7 +148,8 @@ impl GpuForest {
             .iter()
             .map(|n| GpuNode {
                 feature_index: n.feature_index,
-                is_leaf: n.is_leaf as u32,
+                // FlatNode no longer carries is_leaf; derive it from left < 0.
+                is_leaf: (n.left < 0) as u32,
                 threshold: n.threshold as f32,
                 leaf_value: n.leaf_value as f32,
                 left: n.left,

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -388,7 +388,9 @@ impl GpuForest {
 
         // Ensure row-major contiguous layout (zero-copy if already standard layout).
         let X_c = X.as_standard_layout();
-        let features = X_c.as_slice().expect("standard layout is always contiguous");
+        let features = X_c
+            .as_slice()
+            .expect("standard layout is always contiguous");
 
         let shared = &self.shared;
         let device = &shared.device;

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -283,22 +283,6 @@ impl GpuForest {
         if n_samples == 0 {
             return vec![];
         }
-        pollster::block_on(self.predict_async(features, n_samples))
-    }
-
-    /// Async batched inference on `n_samples` samples. Use this if you need to
-    /// await other async work between GPU submission and result retrieval.
-    ///
-    /// `features` is a row-major f32 slice of shape `(n_samples, n_features)`.
-    /// Returns one f32 prediction per sample (mean of all tree predictions).
-    ///
-    /// # Panics
-    ///
-    /// Panics if `n_samples > max_samples` (the value passed to [`from_flat_forest`]).
-    pub async fn predict_async(&self, features: &[f32], n_samples: usize) -> Vec<f32> {
-        if n_samples == 0 {
-            return vec![];
-        }
         assert!(
             n_samples <= self.max_samples,
             "n_samples={n_samples} exceeds max_samples={}",
@@ -417,7 +401,7 @@ impl GpuForest {
         device
             .poll(wgpu::PollType::Wait {
                 submission_index: Some(submit_idx),
-                timeout: None,
+                timeout: Some(std::time::Duration::from_secs(10)),
             })
             .expect("GPU poll failed");
 

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -1,7 +1,7 @@
 use crate::flat_forest::FlatForest;
 use wgpu::util::DeviceExt;
 
-/// GPU representation of a single node (f32, 16 bytes, bytemuck-compatible).
+/// GPU representation of a single node (f32/i32, 24 bytes, bytemuck-compatible).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 struct GpuNode {
@@ -9,6 +9,10 @@ struct GpuNode {
     is_leaf: u32,
     threshold: f32,
     leaf_value: f32,
+    /// Left child index within the tree's node slice, or -1 for leaves.
+    left: i32,
+    /// Right child index within the tree's node slice, or -1 for leaves.
+    right: i32,
 }
 
 /// Forest metadata passed to every shader invocation.
@@ -74,6 +78,8 @@ impl GpuForest {
                 is_leaf: n.is_leaf as u32,
                 threshold: n.threshold as f32,
                 leaf_value: n.leaf_value as f32,
+                left: n.left,
+                right: n.right,
             })
             .collect();
 

--- a/src/gpu/pipeline.rs
+++ b/src/gpu/pipeline.rs
@@ -206,12 +206,17 @@ impl GpuContext {
             .features()
             .contains(wgpu::Features::MAPPABLE_PRIMARY_BUFFERS);
 
+        let adapter_limits = adapter.limits();
         let (device, queue): (wgpu::Device, wgpu::Queue) = adapter
             .request_device(&wgpu::DeviceDescriptor {
                 required_features: if uma {
                     wgpu::Features::MAPPABLE_PRIMARY_BUFFERS
                 } else {
                     wgpu::Features::empty()
+                },
+                required_limits: wgpu::Limits {
+                    max_storage_buffer_binding_size: adapter_limits.max_storage_buffer_binding_size,
+                    ..Default::default()
                 },
                 ..Default::default()
             })

--- a/src/gpu/shaders/reduce.wgsl
+++ b/src/gpu/shaders/reduce.wgsl
@@ -1,14 +1,18 @@
 // Reduction kernel: average per-tree predictions into final per-sample output.
 //
-// Dispatch: (ceil(n_samples / 64), 1, 1)
-// Workgroup size: (64, 1, 1)
+// Dispatch: (ceil(n_samples / wg_size), 1, 1)
+// Workgroup size: (wg_size, 1, 1) — set at pipeline-compile time via override.
+
+/// Number of threads per workgroup in the X dimension.
+/// Overridden at pipeline-compile time with the value queried from device limits.
+override wg_size: u32 = 64u;
 
 // per_tree_preds: column-major, shape (n_trees, n_samples)
 @group(0) @binding(0) var<storage, read> per_tree_preds: array<f32>;
 // output: shape (n_samples,)
 @group(0) @binding(1) var<storage, read_write> output: array<f32>;
 
-@compute @workgroup_size(64, 1, 1)
+@compute @workgroup_size(wg_size, 1, 1)
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let n_samples = arrayLength(&output);
     let n_trees = arrayLength(&per_tree_preds) / n_samples;

--- a/src/gpu/shaders/reduce.wgsl
+++ b/src/gpu/shaders/reduce.wgsl
@@ -1,0 +1,26 @@
+// Reduction kernel: average per-tree predictions into final per-sample output.
+//
+// Dispatch: (ceil(n_samples / 64), 1, 1)
+// Workgroup size: (64, 1, 1)
+
+// per_tree_preds: row-major, shape (n_samples, n_trees)
+@group(0) @binding(0) var<storage, read> per_tree_preds: array<f32>;
+// output: shape (n_samples,)
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+
+@compute @workgroup_size(64, 1, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let n_samples = arrayLength(&output);
+    let n_trees = arrayLength(&per_tree_preds) / n_samples;
+    let sample_id = gid.x;
+
+    if sample_id >= n_samples {
+        return;
+    }
+
+    var sum: f32 = 0.0;
+    for (var t: u32 = 0u; t < n_trees; t = t + 1u) {
+        sum = sum + per_tree_preds[sample_id * n_trees + t];
+    }
+    output[sample_id] = sum / f32(n_trees);
+}

--- a/src/gpu/shaders/reduce.wgsl
+++ b/src/gpu/shaders/reduce.wgsl
@@ -3,7 +3,7 @@
 // Dispatch: (ceil(n_samples / 64), 1, 1)
 // Workgroup size: (64, 1, 1)
 
-// per_tree_preds: row-major, shape (n_samples, n_trees)
+// per_tree_preds: column-major, shape (n_trees, n_samples)
 @group(0) @binding(0) var<storage, read> per_tree_preds: array<f32>;
 // output: shape (n_samples,)
 @group(0) @binding(1) var<storage, read_write> output: array<f32>;
@@ -20,7 +20,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
 
     var sum: f32 = 0.0;
     for (var t: u32 = 0u; t < n_trees; t = t + 1u) {
-        sum = sum + per_tree_preds[sample_id * n_trees + t];
+        sum = sum + per_tree_preds[t * n_samples + sample_id];
     }
     output[sample_id] = sum / f32(n_trees);
 }

--- a/src/gpu/shaders/traverse.wgsl
+++ b/src/gpu/shaders/traverse.wgsl
@@ -29,7 +29,7 @@ struct Meta {
 @group(0) @binding(1) var<storage, read> nodes: array<Node>;
 // features: row-major, shape (n_samples, n_features)
 @group(0) @binding(2) var<storage, read> features: array<f32>;
-// per_tree_preds: row-major, shape (n_samples, n_trees)
+// per_tree_preds: column-major, shape (n_trees, n_samples)
 @group(0) @binding(3) var<storage, read_write> per_tree_preds: array<f32>;
 
 @compute @workgroup_size(64, 1, 1)
@@ -49,7 +49,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     for (var i: u32 = 0u; i <= forest_meta.max_depth; i = i + 1u) {
         let node = nodes[tree_offset + node_idx];
         if node.is_leaf == 1u {
-            per_tree_preds[sample_id * forest_meta.n_trees + tree_id] = node.leaf_value;
+            per_tree_preds[tree_id * n_samples + sample_id] = node.leaf_value;
             return;
         }
         let feat_val = features[sample_id * forest_meta.n_features + node.feature_index];
@@ -61,5 +61,5 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
         }
     }
     // Fallback: should not reach here for well-formed trees.
-    per_tree_preds[sample_id * forest_meta.n_trees + tree_id] = nodes[tree_offset + node_idx].leaf_value;
+    per_tree_preds[tree_id * n_samples + sample_id] = nodes[tree_offset + node_idx].leaf_value;
 }

--- a/src/gpu/shaders/traverse.wgsl
+++ b/src/gpu/shaders/traverse.wgsl
@@ -5,17 +5,19 @@
 //
 // Nodes are stored in BFS visit order with explicit left/right child indices,
 // so trees of any depth and shape are supported without exponential padding.
+// Field layout matches FlatNode in flat_forest.rs exactly (repr(C), all 4-byte
+// fields): left, right, feature_index, threshold, leaf_value.
+// A node is a leaf when left < 0.
 //
 // Dispatch: (ceil(n_samples / 64), n_trees, 1)
 // Workgroup size: (64, 1, 1)
 
 struct Node {
-    feature_index: u32,
-    is_leaf: u32,
-    threshold: f32,
-    leaf_value: f32,
     left: i32,
     right: i32,
+    feature_index: u32,
+    threshold: f32,
+    leaf_value: f32,
 }
 
 struct Meta {
@@ -48,7 +50,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     // Traverse at most max_depth + 1 steps as a safety bound.
     for (var i: u32 = 0u; i <= forest_meta.max_depth; i = i + 1u) {
         let node = nodes[tree_offset + node_idx];
-        if node.is_leaf == 1u {
+        if node.left < 0 {
             per_tree_preds[tree_id * n_samples + sample_id] = node.leaf_value;
             return;
         }

--- a/src/gpu/shaders/traverse.wgsl
+++ b/src/gpu/shaders/traverse.wgsl
@@ -1,7 +1,10 @@
 // Tree traversal kernel.
 //
-// Each GPU thread handles one (sample, tree) pair, walking the BFS-encoded node array
+// Each GPU thread handles one (sample, tree) pair, walking the flat node array
 // for that tree to produce a per-tree prediction for that sample.
+//
+// Nodes are stored in BFS visit order with explicit left/right child indices,
+// so trees of any depth and shape are supported without exponential padding.
 //
 // Dispatch: (ceil(n_samples / 64), n_trees, 1)
 // Workgroup size: (64, 1, 1)
@@ -11,6 +14,8 @@ struct Node {
     is_leaf: u32,
     threshold: f32,
     leaf_value: f32,
+    left: i32,
+    right: i32,
 }
 
 struct Meta {
@@ -40,7 +45,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let tree_offset = tree_id * forest_meta.max_tree_size;
     var node_idx: u32 = 0u;
 
-    // Traverse at most max_depth + 1 steps (one extra for the final leaf check).
+    // Traverse at most max_depth + 1 steps as a safety bound.
     for (var i: u32 = 0u; i <= forest_meta.max_depth; i = i + 1u) {
         let node = nodes[tree_offset + node_idx];
         if node.is_leaf == 1u {
@@ -50,9 +55,9 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
         let feat_val = features[sample_id * forest_meta.n_features + node.feature_index];
         // Use strict < to match biosphere's CPU inference exactly.
         if feat_val < node.threshold {
-            node_idx = 2u * node_idx + 1u; // left child
+            node_idx = u32(node.left);
         } else {
-            node_idx = 2u * node_idx + 2u; // right child
+            node_idx = u32(node.right);
         }
     }
     // Fallback: should not reach here for well-formed trees.

--- a/src/gpu/shaders/traverse.wgsl
+++ b/src/gpu/shaders/traverse.wgsl
@@ -6,8 +6,10 @@
 // Nodes are stored in BFS visit order with explicit left/right child indices,
 // so trees of any depth and shape are supported without exponential padding.
 // Field layout matches FlatNode in flat_forest.rs exactly (repr(C), all 4-byte
-// fields): left, right, feature_index, threshold, leaf_value.
-// A node is a leaf when left < 0.
+// fields): left, right, feature_index, value.
+// `value` is the split threshold for internal nodes and the leaf prediction for
+// leaf nodes (left < 0 distinguishes the two cases).
+// This alias keeps Node at 16 bytes = 4 nodes per 64-byte cache line.
 //
 // Dispatch: (ceil(n_samples / 64), n_trees, 1)
 // Workgroup size: (64, 1, 1)
@@ -16,8 +18,7 @@ struct Node {
     left: i32,
     right: i32,
     feature_index: u32,
-    threshold: f32,
-    leaf_value: f32,
+    value: f32,  // threshold (internal) or leaf prediction (leaf)
 }
 
 struct Meta {
@@ -51,17 +52,17 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     for (var i: u32 = 0u; i <= forest_meta.max_depth; i = i + 1u) {
         let node = nodes[tree_offset + node_idx];
         if node.left < 0 {
-            per_tree_preds[tree_id * n_samples + sample_id] = node.leaf_value;
+            per_tree_preds[tree_id * n_samples + sample_id] = node.value;
             return;
         }
         let feat_val = features[sample_id * forest_meta.n_features + node.feature_index];
         // Use strict < to match biosphere's CPU inference exactly.
-        if feat_val < node.threshold {
+        if feat_val < node.value {
             node_idx = u32(node.left);
         } else {
             node_idx = u32(node.right);
         }
     }
     // Fallback: should not reach here for well-formed trees.
-    per_tree_preds[tree_id * n_samples + sample_id] = nodes[tree_offset + node_idx].leaf_value;
+    per_tree_preds[tree_id * n_samples + sample_id] = nodes[tree_offset + node_idx].value;
 }

--- a/src/gpu/shaders/traverse.wgsl
+++ b/src/gpu/shaders/traverse.wgsl
@@ -11,8 +11,12 @@
 // leaf nodes (left < 0 distinguishes the two cases).
 // This alias keeps Node at 16 bytes = 4 nodes per 64-byte cache line.
 //
-// Dispatch: (ceil(n_samples / 64), n_trees, 1)
-// Workgroup size: (64, 1, 1)
+// Dispatch: (ceil(n_samples / wg_size), n_trees, 1)
+// Workgroup size: (wg_size, 1, 1) — set at pipeline-compile time via override.
+
+/// Number of threads per workgroup in the X dimension.
+/// Overridden at pipeline-compile time with the value queried from device limits.
+override wg_size: u32 = 64u;
 
 struct Node {
     left: i32,
@@ -35,7 +39,7 @@ struct Meta {
 // per_tree_preds: column-major, shape (n_trees, n_samples)
 @group(0) @binding(3) var<storage, read_write> per_tree_preds: array<f32>;
 
-@compute @workgroup_size(64, 1, 1)
+@compute @workgroup_size(wg_size, 1, 1)
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let n_samples = arrayLength(&features) / forest_meta.n_features;
     let sample_id = gid.x;

--- a/src/gpu/shaders/traverse.wgsl
+++ b/src/gpu/shaders/traverse.wgsl
@@ -1,0 +1,60 @@
+// Tree traversal kernel.
+//
+// Each GPU thread handles one (sample, tree) pair, walking the BFS-encoded node array
+// for that tree to produce a per-tree prediction for that sample.
+//
+// Dispatch: (ceil(n_samples / 64), n_trees, 1)
+// Workgroup size: (64, 1, 1)
+
+struct Node {
+    feature_index: u32,
+    is_leaf: u32,
+    threshold: f32,
+    leaf_value: f32,
+}
+
+struct Meta {
+    n_trees: u32,
+    n_features: u32,
+    max_tree_size: u32,
+    max_depth: u32,
+}
+
+@group(0) @binding(0) var<storage, read> forest_meta: Meta;
+@group(0) @binding(1) var<storage, read> nodes: array<Node>;
+// features: row-major, shape (n_samples, n_features)
+@group(0) @binding(2) var<storage, read> features: array<f32>;
+// per_tree_preds: row-major, shape (n_samples, n_trees)
+@group(0) @binding(3) var<storage, read_write> per_tree_preds: array<f32>;
+
+@compute @workgroup_size(64, 1, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let n_samples = arrayLength(&features) / forest_meta.n_features;
+    let sample_id = gid.x;
+    let tree_id = gid.y;
+
+    if sample_id >= n_samples {
+        return;
+    }
+
+    let tree_offset = tree_id * forest_meta.max_tree_size;
+    var node_idx: u32 = 0u;
+
+    // Traverse at most max_depth + 1 steps (one extra for the final leaf check).
+    for (var i: u32 = 0u; i <= forest_meta.max_depth; i = i + 1u) {
+        let node = nodes[tree_offset + node_idx];
+        if node.is_leaf == 1u {
+            per_tree_preds[sample_id * forest_meta.n_trees + tree_id] = node.leaf_value;
+            return;
+        }
+        let feat_val = features[sample_id * forest_meta.n_features + node.feature_index];
+        // Use strict < to match biosphere's CPU inference exactly.
+        if feat_val < node.threshold {
+            node_idx = 2u * node_idx + 1u; // left child
+        } else {
+            node_idx = 2u * node_idx + 2u; // right child
+        }
+    }
+    // Fallback: should not reach here for well-formed trees.
+    per_tree_preds[sample_id * forest_meta.n_trees + tree_id] = nodes[tree_offset + node_idx].leaf_value;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,8 @@ mod forest;
 mod tree;
 pub mod utils; // This is public for benchmarking only.
 
+#[cfg(feature = "gpu")]
+pub mod gpu;
+
 #[cfg(test)]
 mod testing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,31 @@
+//! Fast, simple random forests in Rust.
+//!
+//! Biosphere trains and runs decision-tree ensembles for regression or binary
+//! classification on tabular data. It is designed to be easy to use with minimal
+//! hyperparameter tuning: adjust tree count and seed, everything else has sensible
+//! defaults.
+//!
+//! # Quickstart
+//!
+//! ```rust
+//! use biosphere::{RandomForest, RandomForestParameters};
+//! use ndarray::array;
+//!
+//! let X = array![[0.0, 1.0], [1.0, 0.0], [0.0, 0.0], [1.0, 1.0]];
+//! let y = array![0.0, 1.0, 0.0, 1.0];
+//!
+//! let mut forest = RandomForest::new(RandomForestParameters::default());
+//! forest.fit(&X.view(), &y.view());
+//!
+//! let predictions = forest.predict(&X.view());
+//! ```
+//!
+//! # GPU inference
+//!
+//! Enable the `gpu` cargo feature to convert a trained forest to a [`FlatForest`]
+//! and upload it to a [`gpu::GpuForest`] for batched inference on Metal, Vulkan,
+//! or DX12. See the [`gpu`] module for a complete example.
+
 // Allow capital X for arrays.
 #![allow(non_snake_case)]
 pub use flat_forest::{FlatForest, FlatNode};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 
 // Allow capital X for arrays.
 #![allow(non_snake_case)]
-pub use flat_forest::{FlatForest, FlatNode};
+pub use flat_forest::{FlatForest, FlatNode, ForestMeta};
 pub use forest::RandomForest;
 pub use forest::RandomForestParameters;
 pub use tree::{DecisionTree, DecisionTreeParameters, MaxFeatures};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 // Allow capital X for arrays.
 #![allow(non_snake_case)]
+pub use flat_forest::{FlatForest, FlatNode};
 pub use forest::RandomForest;
 pub use forest::RandomForestParameters;
 pub use tree::{DecisionTree, DecisionTreeParameters, MaxFeatures};
+mod flat_forest;
 mod forest;
 mod tree;
 pub mod utils; // This is public for benchmarking only.

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -13,7 +13,5 @@ pub fn is_sorted(data: &ArrayBase<impl Data<Elem = f64>, Ix1>) -> bool {
 pub fn load_iris() -> Array2<f64> {
     let file = File::open("testdata/iris.csv").unwrap();
     let mut reader = ReaderBuilder::new().has_headers(true).from_reader(file);
-    let data = reader.deserialize_array2::<f64>((150, 5)).unwrap();
-
-    data
+    reader.deserialize_array2::<f64>((150, 5)).unwrap()
 }

--- a/src/tree/decision_tree.rs
+++ b/src/tree/decision_tree.rs
@@ -5,6 +5,25 @@ use ndarray::{Array1, ArrayView1, ArrayView2};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
+/// A single decision tree for regression or binary classification.
+///
+/// Splits features greedily to minimise impurity. Useful on its own for
+/// interpretable models; most users will prefer [`RandomForest`], which
+/// ensembles many trees for lower variance.
+///
+/// ```rust
+/// use biosphere::{DecisionTree, DecisionTreeParameters};
+/// use ndarray::array;
+///
+/// let X = array![[0.0, 1.0], [1.0, 0.0]];
+/// let y = array![0.0, 1.0];
+///
+/// let mut tree = DecisionTree::new(DecisionTreeParameters::default());
+/// tree.fit_with_samples(&X.view(), &y.view(), &[0, 1]);
+/// let predictions = tree.predict(&X.view());
+/// ```
+///
+/// [`RandomForest`]: crate::RandomForest
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct DecisionTree {

--- a/src/tree/decision_tree.rs
+++ b/src/tree/decision_tree.rs
@@ -5,6 +5,7 @@ use ndarray::{Array1, ArrayView1, ArrayView2};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct DecisionTree {
     decision_tree_parameters: DecisionTreeParameters,
     node: DecisionTreeNode,
@@ -121,4 +122,25 @@ mod tests {
         // perfectly replicate these with another decision tree.
         assert_eq!(predictions - another_predictions, Array1::<f64>::zeros(150));
     }
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serialized_deserialized_tree_predicts_same_as_fit_tree() {
+    let data = load_iris();
+    let X = data.slice(s![.., 0..4]);
+    let y = data.slice(s![.., 4]);
+
+    let parameters = DecisionTreeParameters::default()
+        .with_max_depth(Some(4))
+        .with_max_features(MaxFeatures::Value(2))
+        .with_random_state(123);
+    let mut tree = DecisionTree::new(parameters);
+    tree.fit(&X, &y);
+    let predictions = tree.predict(&X);
+
+    let bytes = postcard::to_stdvec(&tree).unwrap();
+    let restored_tree: DecisionTree = postcard::from_bytes(bytes.as_slice()).unwrap();
+
+    assert_eq!(predictions, restored_tree.predict(&X));
 }

--- a/src/tree/decision_tree.rs
+++ b/src/tree/decision_tree.rs
@@ -72,6 +72,8 @@ impl DecisionTree {
 
         let n_samples = samples[0].len();
         let mut all_false = vec![false; X.nrows()];
+        let mut feature_order = Vec::with_capacity(X.ncols());
+        let mut right_scratch = Vec::with_capacity(n_samples);
 
         self.node.split(
             X,
@@ -80,6 +82,8 @@ impl DecisionTree {
             n_samples,
             vec![false; X.ncols()],
             &mut all_false,
+            &mut feature_order,
+            &mut right_scratch,
             sum,
             &mut rng,
             0,
@@ -89,10 +93,14 @@ impl DecisionTree {
 
     pub fn predict(&self, X: &ArrayView2<f64>) -> Array1<f64> {
         let mut predictions = Array1::<f64>::zeros(X.nrows());
-        for row in 0..X.nrows() {
-            predictions[row] = self.predict_row(&X.row(row));
-        }
+        self.predict_into(X, &mut predictions);
         predictions
+    }
+
+    pub fn predict_into(&self, X: &ArrayView2<f64>, out: &mut Array1<f64>) {
+        for row in 0..X.nrows() {
+            out[row] = self.predict_row(&X.row(row));
+        }
     }
 
     pub fn predict_row(&self, X: &ArrayView1<f64>) -> f64 {

--- a/src/tree/decision_tree.rs
+++ b/src/tree/decision_tree.rs
@@ -93,6 +93,10 @@ impl DecisionTree {
         let samples: Vec<usize> = (0..X.nrows()).collect();
         self.fit_with_samples(X, y, &samples);
     }
+
+    pub(crate) fn root(&self) -> &DecisionTreeNode {
+        &self.node
+    }
 }
 
 #[cfg(test)]

--- a/src/tree/decision_tree.rs
+++ b/src/tree/decision_tree.rs
@@ -128,6 +128,9 @@ mod tests {
 #[cfg(feature = "serde")]
 #[test]
 fn test_serialized_deserialized_tree_predicts_same_as_fit_tree() {
+    use crate::{MaxFeatures, testing::load_iris};
+    use ndarray::s;
+
     let data = load_iris();
     let X = data.slice(s![.., 0..4]);
     let y = data.slice(s![.., 4]);

--- a/src/tree/decision_tree.rs
+++ b/src/tree/decision_tree.rs
@@ -1,9 +1,9 @@
-use crate::tree::decision_tree_node::DecisionTreeNode;
 use crate::tree::DecisionTreeParameters;
+use crate::tree::decision_tree_node::DecisionTreeNode;
 use crate::utils::sorted_samples;
 use ndarray::{Array1, ArrayView1, ArrayView2};
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/src/tree/decision_tree.rs
+++ b/src/tree/decision_tree.rs
@@ -5,6 +5,7 @@ use ndarray::{Array1, ArrayView1, ArrayView2};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
+#[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct DecisionTree {
     decision_tree_parameters: DecisionTreeParameters,

--- a/src/tree/decision_tree_node.rs
+++ b/src/tree/decision_tree_node.rs
@@ -8,6 +8,7 @@ static MIN_GAIN_TO_SPLIT: f64 = 1e-12;
 static FEATURE_THRESHOLD: f64 = 1e-14;
 
 #[derive(Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct DecisionTreeNode {
     pub left_child: Option<Box<DecisionTreeNode>>,
     pub right_child: Option<Box<DecisionTreeNode>>,

--- a/src/tree/decision_tree_node.rs
+++ b/src/tree/decision_tree_node.rs
@@ -244,8 +244,12 @@ impl DecisionTreeNode {
         // any index directly (O(1)) instead of using Vec::insert (O(n_features)).
         // Safety: the empty slice is never read before being overwritten; every
         // slot is assigned exactly once during the loop or the deferred block.
-        let mut new_samples_left: Vec<&mut [usize]> = (0..n_features).map(|_| -> &mut [usize] { &mut [] }).collect();
-        let mut new_samples_right: Vec<&mut [usize]> = (0..n_features).map(|_| -> &mut [usize] { &mut [] }).collect();
+        let mut new_samples_left: Vec<&mut [usize]> = (0..n_features)
+            .map(|_| -> &mut [usize] { &mut [] })
+            .collect();
+        let mut new_samples_right: Vec<&mut [usize]> = (0..n_features)
+            .map(|_| -> &mut [usize] { &mut [] })
+            .collect();
 
         let mut first_left: &mut [usize] = &mut [];
         right_scratch.clear();

--- a/src/tree/decision_tree_node.rs
+++ b/src/tree/decision_tree_node.rs
@@ -6,6 +6,7 @@ use std::debug_assert;
 
 static MIN_GAIN_TO_SPLIT: f64 = 1e-12;
 static FEATURE_THRESHOLD: f64 = 1e-14;
+static SPLIT_VALUE_THRESHOLD: f64 = 1e-12;
 
 #[derive(Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -32,6 +33,10 @@ impl DecisionTreeNode {
         mut constant_features: Vec<bool>,
         // Used in split_samples. Passed here to avoid reallocating.
         all_false: &mut [bool],
+        // Scratch buffer for feature order; pre-allocated at root call site.
+        feature_order: &mut Vec<usize>,
+        // Scratch buffer used inside split_samples; pre-allocated at root call site.
+        right_scratch: &mut Vec<usize>,
         sum: f64,
         rng: &mut impl Rng,
         current_depth: usize,
@@ -53,7 +58,8 @@ impl DecisionTreeNode {
         let mut best_feature = 0;
         let mut left_sum_at_best_split = 0.;
 
-        let mut feature_order = (0..X.ncols()).collect::<Vec<usize>>();
+        feature_order.clear();
+        feature_order.extend(0..X.ncols());
         feature_order.shuffle(rng);
 
         for (feature_idx, &feature) in feature_order.iter().enumerate() {
@@ -98,6 +104,7 @@ impl DecisionTreeNode {
             &constant_features,
             best_feature,
             all_false,
+            right_scratch,
         );
 
         let mut left = DecisionTreeNode::default();
@@ -108,6 +115,8 @@ impl DecisionTreeNode {
             best_split,
             constant_features.clone(),
             all_false,
+            feature_order,
+            right_scratch,
             left_sum_at_best_split,
             rng,
             current_depth + 1,
@@ -123,6 +132,8 @@ impl DecisionTreeNode {
             n_samples - best_split,
             constant_features,
             all_false,
+            feature_order,
+            right_scratch,
             sum - left_sum_at_best_split,
             rng,
             current_depth + 1,
@@ -156,7 +167,7 @@ impl DecisionTreeNode {
             cumsum += y[samples[s - 1]];
 
             // Hackedy hack.
-            if X[[samples[s], feature]] - X[[samples[s - 1], feature]] < 1e-12 {
+            if X[[samples[s], feature]] - X[[samples[s - 1], feature]] < SPLIT_VALUE_THRESHOLD {
                 continue;
             }
 
@@ -215,6 +226,9 @@ impl DecisionTreeNode {
         best_feature: usize,
         // best_split_val: f64,
         all_false: &mut [bool],
+        // Scratch buffer for the first non-constant, non-best-feature right partition.
+        // Pre-allocated at the root call site to avoid per-node heap allocation.
+        right_scratch: &mut Vec<usize>,
     ) -> (Vec<&'a mut [usize]>, Vec<&'a mut [usize]>) {
         // We replace lookups & comparisons X[[idx, best_feature]] > best_split_val
         // with a lookup all_false[idx]. This is faster. Since best_feature was split
@@ -223,12 +237,18 @@ impl DecisionTreeNode {
             all_false[*s] = true;
         }
 
+        let n_features = samples.len();
         let n = samples[best_feature].len();
-        let mut new_samples_left = Vec::<&mut [usize]>::with_capacity(samples.len());
-        let mut new_samples_right = Vec::<&mut [usize]>::with_capacity(samples.len());
+
+        // Pre-fill output vecs with empty-slice placeholders so we can write to
+        // any index directly (O(1)) instead of using Vec::insert (O(n_features)).
+        // Safety: the empty slice is never read before being overwritten; every
+        // slot is assigned exactly once during the loop or the deferred block.
+        let mut new_samples_left: Vec<&mut [usize]> = (0..n_features).map(|_| -> &mut [usize] { &mut [] }).collect();
+        let mut new_samples_right: Vec<&mut [usize]> = (0..n_features).map(|_| -> &mut [usize] { &mut [] }).collect();
 
         let mut first_left: &mut [usize] = &mut [];
-        let mut copy_of_first_right: Vec<usize> = Vec::with_capacity(n - split);
+        right_scratch.clear();
         let mut initialized = false;
         let mut index_of_first: usize = 0;
 
@@ -240,21 +260,20 @@ impl DecisionTreeNode {
         for (feature, sample_) in samples.into_iter().enumerate() {
             if feature == best_feature {
                 let (left, right) = sample_.split_at_mut(split);
-                new_samples_left.push(left);
-                new_samples_right.push(right);
+                new_samples_left[feature] = left;
+                new_samples_right[feature] = right;
                 continue;
             }
 
             if constant_features[feature] {
-                new_samples_left.push(&mut []);
-                new_samples_right.push(&mut []);
+                // Placeholders already set; nothing to do.
                 continue;
             }
 
             if !initialized {
                 let result = sample_.split_at_mut(split);
                 new_right = result.1;
-                copy_of_first_right.extend_from_slice(new_right);
+                right_scratch.extend_from_slice(new_right);
                 first_left = result.0;
                 index_of_first = feature;
                 initialized = true;
@@ -282,8 +301,8 @@ impl DecisionTreeNode {
             }
 
             let result = sample_.split_at_mut(split);
-            new_samples_left.push(result.0);
-            new_samples_right.push(new_right);
+            new_samples_left[feature] = result.0;
+            new_samples_right[feature] = new_right;
             new_right = result.1;
         }
 
@@ -303,17 +322,18 @@ impl DecisionTreeNode {
             }
 
             for idx in 0..(n - split) {
-                // if X[[copy_of_first_right[idx], best_feature]] > best_split_val {
-                if all_false[copy_of_first_right[idx]] {
-                    new_right[current_right] = copy_of_first_right[idx];
+                // if X[[right_scratch[idx], best_feature]] > best_split_val {
+                if all_false[right_scratch[idx]] {
+                    new_right[current_right] = right_scratch[idx];
                     current_right += 1;
                 } else {
-                    first_left[current_left] = copy_of_first_right[idx];
+                    first_left[current_left] = right_scratch[idx];
                     current_left += 1;
                 }
             }
-            new_samples_left.insert(index_of_first, first_left);
-            new_samples_right.insert(index_of_first, new_right);
+            // Direct index write — O(1), no shifting.
+            new_samples_left[index_of_first] = first_left;
+            new_samples_right[index_of_first] = new_right;
         }
 
         // Reset all_false to be all false.
@@ -427,6 +447,7 @@ mod tests {
 
         let node = DecisionTreeNode::default();
         let mut all_false = vec![false; X.nrows()];
+        let mut right_scratch = Vec::with_capacity(n_samples);
 
         let (left, right) = node.split_samples(
             samples_references,
@@ -434,6 +455,7 @@ mod tests {
             &all_false_but_first,
             best_feature,
             &mut all_false,
+            &mut right_scratch,
         );
 
         assert!(left.len() == d);

--- a/src/tree/decision_tree_node.rs
+++ b/src/tree/decision_tree_node.rs
@@ -1,7 +1,7 @@
 use crate::tree::DecisionTreeParameters;
 use ndarray::{ArrayView1, ArrayView2};
-use rand::seq::SliceRandom;
 use rand::Rng;
+use rand::seq::SliceRandom;
 use std::debug_assert;
 
 static MIN_GAIN_TO_SPLIT: f64 = 1e-12;
@@ -38,9 +38,10 @@ impl DecisionTreeNode {
         parameters: &DecisionTreeParameters,
     ) {
         if let Some(depth) = parameters.max_depth
-            && current_depth >= depth {
-                return self.leaf_node(sum / n_samples as f64);
-            }
+            && current_depth >= depth
+        {
+            return self.leaf_node(sum / n_samples as f64);
+        }
 
         if n_samples <= parameters.min_samples_split {
             return self.leaf_node(sum / n_samples as f64);
@@ -330,11 +331,11 @@ mod tests {
     use crate::testing::is_sorted;
     use crate::utils::sorted_samples;
     use assert_approx_eq::*;
-    use ndarray::{arr1, arr2, s, Array, Array1, Axis};
-    use ndarray_rand::rand_distr::Uniform;
+    use ndarray::{Array, Array1, Axis, arr1, arr2, s};
     use ndarray_rand::RandomExt;
-    use rand::rngs::StdRng;
+    use ndarray_rand::rand_distr::Uniform;
     use rand::SeedableRng;
+    use rand::rngs::StdRng;
     use rstest::*;
 
     #[rstest]

--- a/src/tree/decision_tree_node.rs
+++ b/src/tree/decision_tree_node.rs
@@ -410,7 +410,11 @@ mod tests {
 
         let node = DecisionTreeNode::default();
         let mut samples = (0..100).collect::<Vec<usize>>();
-        samples.sort_unstable_by(|a, b| X[[*a, 0]].partial_cmp(&X[[*b, 0]]).unwrap());
+        samples.sort_unstable_by(|a, b| {
+            let xa: f64 = X[[*a, 0]];
+            let xb: f64 = X[[*b, 0]];
+            xa.total_cmp(&xb)
+        });
 
         let (split, split_val, gain, sum) =
             node.find_best_split(&X.view(), &y.view(), 0, &samples, 0.);

--- a/src/tree/decision_tree_node.rs
+++ b/src/tree/decision_tree_node.rs
@@ -7,7 +7,7 @@ use std::debug_assert;
 static MIN_GAIN_TO_SPLIT: f64 = 1e-12;
 static FEATURE_THRESHOLD: f64 = 1e-14;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct DecisionTreeNode {
     pub left_child: Option<Box<DecisionTreeNode>>,

--- a/src/tree/decision_tree_node.rs
+++ b/src/tree/decision_tree_node.rs
@@ -37,11 +37,10 @@ impl DecisionTreeNode {
         current_depth: usize,
         parameters: &DecisionTreeParameters,
     ) {
-        if let Some(depth) = parameters.max_depth {
-            if current_depth >= depth {
+        if let Some(depth) = parameters.max_depth
+            && current_depth >= depth {
                 return self.leaf_node(sum / n_samples as f64);
             }
-        }
 
         if n_samples <= parameters.min_samples_split {
             return self.leaf_node(sum / n_samples as f64);

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -3,4 +3,5 @@ mod decision_tree_node;
 mod decision_tree_parameters;
 
 pub use decision_tree::DecisionTree;
+pub(crate) use decision_tree_node::DecisionTreeNode;
 pub use decision_tree_parameters::{DecisionTreeParameters, MaxFeatures};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 ///
 /// Parameters
 /// ----------
-/// data: Array1<f64> or ArrayView1<f64>
+/// data: `Array1<f64>` or `ArrayView1<f64>`
 pub fn argsort(data: &ArrayBase<impl Data<Elem = f64>, Ix1>) -> Vec<usize> {
     let mut indices = (0..data.len()).collect::<Vec<usize>>();
     indices.sort_unstable_by(|a, b| data[*a].partial_cmp(&data[*b]).unwrap());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 /// data: `Array1<f64>` or `ArrayView1<f64>`
 pub fn argsort(data: &ArrayBase<impl Data<Elem = f64>, Ix1>) -> Vec<usize> {
     let mut indices = (0..data.len()).collect::<Vec<usize>>();
-    indices.sort_unstable_by(|a, b| data[*a].partial_cmp(&data[*b]).unwrap());
+    indices.sort_unstable_by(|a, b| data[*a].total_cmp(&data[*b]));
     indices
 }
 
@@ -56,7 +56,7 @@ pub fn sorted_samples(
 
     for idx in 0..X.ncols() {
         let mut samples_ = samples.to_vec();
-        samples_.sort_by(|a, b| X[[*a, idx]].partial_cmp(&X[[*b, idx]]).unwrap());
+        samples_.sort_by(|a, b| X[[*a, idx]].total_cmp(&X[[*b, idx]]));
         samples_out.push(samples_);
     }
     samples_out

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -113,10 +113,8 @@ mod tests {
 
         let samples = sample_indices_from_weights(&weights, &indices);
 
-        for feature in 0..X.ncols() {
-            assert!(is_sorted(
-                &X.column(feature).select(Axis(0), &samples[feature])
-            ));
+        for (feature, sample) in samples.iter().enumerate().take(X.ncols()) {
+            assert!(is_sorted(&X.column(feature).select(Axis(0), sample)));
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -67,10 +67,10 @@ mod tests {
     use super::*;
     use crate::testing::is_sorted;
     use ndarray::{Array, Axis};
-    use ndarray_rand::rand_distr::Uniform;
     use ndarray_rand::RandomExt;
-    use rand::rngs::StdRng;
+    use ndarray_rand::rand_distr::Uniform;
     use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     #[test]
     fn test_argsort() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,8 @@ use rand::Rng;
 
 /// Compute `indices` such that `data.select(indices)` is sorted.
 ///
+/// NaN values, if present, are sorted after all finite values (IEEE 754 total order).
+///
 /// Parameters
 /// ----------
 /// data: `Array1<f64>` or `ArrayView1<f64>`
@@ -48,6 +50,9 @@ pub fn oob_samples_from_weights(weights: &[usize]) -> Vec<usize> {
     oob_samples
 }
 
+/// For each feature column, return `samples` sorted by ascending feature value.
+///
+/// NaN values, if present, are sorted after all finite values (IEEE 754 total order).
 pub fn sorted_samples(
     X: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     samples: &[usize],

--- a/tests/flat_forest.rs
+++ b/tests/flat_forest.rs
@@ -7,6 +7,20 @@ use ndarray_rand::rand_distr::Uniform;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
+fn assert_flat_matches_recursive(
+    forest: &RandomForest,
+    test_X: &Array2<f64>,
+    n_features: usize,
+) {
+    let cpu_preds = forest.predict(&test_X.view());
+    let flat = FlatForest::from_forest(forest, n_features);
+    let test_X_f32 = test_X.mapv(|v| v as f32);
+    let flat_preds = flat.predict(&test_X_f32.view());
+    for (i, (cpu, fp)) in cpu_preds.iter().zip(flat_preds.iter()).enumerate() {
+        assert!((cpu - fp).abs() < 1e-5, "sample {i}: cpu={cpu}, flat={fp}");
+    }
+}
+
 fn make_data(n_samples: usize, n_features: usize, seed: u64) -> (Array2<f64>, Array1<f64>) {
     let mut rng = StdRng::seed_from_u64(seed);
     // Keep values in [0, 1) to avoid cumsum precision issues in biosphere internals.
@@ -83,16 +97,189 @@ fn flat_forest_deep_tree() {
     forest.fit(&X.view(), &y.view());
 
     let (test_X, _) = make_data(50, 8, 456);
-    let cpu_preds = forest.predict(&test_X.view());
-    let flat = FlatForest::from_forest(&forest, 8);
-    let test_X_f32 = test_X.mapv(|v| v as f32);
-    let flat_preds = flat.predict(&test_X_f32.view());
+    assert_flat_matches_recursive(&forest, &test_X, 8);
+}
 
-    for (i, (cpu, flat)) in cpu_preds.iter().zip(flat_preds.iter()).enumerate() {
-        // FlatForest stores nodes as f32; allow for f32 quantisation error.
+// --- Test #1: depth-0 tree (single leaf) ---
+/// min_samples_split >= n_samples forces every tree to be a single leaf.
+/// max_tree_size must be 1, max_depth must be 0, and all test samples receive
+/// the same averaged prediction (since each tree returns one constant value).
+#[test]
+fn depth_zero_single_leaf() {
+    let n_train = 50;
+    let (X, y) = make_data(n_train, 4, 11);
+    // n_samples <= min_samples_split → root cannot split → single leaf.
+    let params = RandomForestParameters::default()
+        .with_n_estimators(5)
+        .with_min_samples_split(n_train)
+        .with_seed(10);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let flat = FlatForest::from_forest(&forest, 4);
+    assert_eq!(flat.max_tree_size, 1, "depth-0 forest: max_tree_size should be 1");
+    assert_eq!(flat.max_depth, 0, "depth-0 forest: max_depth should be 0");
+
+    let (test_X, _) = make_data(20, 4, 999);
+    let test_X_f32 = test_X.mapv(|v| v as f32);
+    let preds = flat.predict(&test_X_f32.view());
+    // Each tree returns its single leaf value regardless of input; averaged output is
+    // the same constant for every test sample.
+    let first = preds[0];
+    for &p in preds.iter() {
         assert!(
-            (cpu - flat).abs() < 1e-5,
-            "sample {i}: cpu={cpu}, flat={flat}"
+            (p - first).abs() < 1e-10,
+            "depth-0 forest: all predictions should be equal across test samples"
         );
+    }
+}
+
+// --- Test #2: depth-1 forest ---
+/// max_depth=Some(1) means each tree has at most one split (≤ 3 nodes).
+#[test]
+fn depth_one_forest() {
+    let (X, y) = make_data(100, 5, 22);
+    let params = RandomForestParameters::default()
+        .with_n_estimators(10)
+        .with_max_depth(Some(1))
+        .with_seed(20);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let flat = FlatForest::from_forest(&forest, 5);
+    // A depth-1 tree is root + at most 2 leaves = 3 nodes.
+    assert!(flat.max_tree_size <= 3, "depth-1 forest: max_tree_size={}", flat.max_tree_size);
+    assert!(flat.max_depth <= 1, "depth-1 forest: max_depth={}", flat.max_depth);
+
+    let (test_X, _) = make_data(50, 5, 222);
+    assert_flat_matches_recursive(&forest, &test_X, 5);
+}
+
+// --- Test #5: feature at last index ---
+/// With n_features=1, every split uses feature_index=0 = n_features-1.
+/// Tests that the last feature index is handled correctly (no off-by-one).
+#[test]
+fn feature_at_last_index() {
+    let n_features = 1;
+    let mut rng = StdRng::seed_from_u64(55);
+    let X = Array2::random_using((100, n_features), Uniform::new(0.0, 1.0).unwrap(), &mut rng);
+    let y = X.column(0).to_owned();
+
+    let params = RandomForestParameters::default()
+        .with_n_estimators(10)
+        .with_seed(5);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let test_X = Array2::random_using((30, n_features), Uniform::new(0.0, 1.0).unwrap(), &mut rng);
+    assert_flat_matches_recursive(&forest, &test_X, n_features);
+
+    // The forest must produce varied predictions (confirming splits on feature 0 = last feature).
+    let cpu_preds = forest.predict(&test_X.view());
+    let all_same = cpu_preds.iter().all(|&p| (p - cpu_preds[0]).abs() < 1e-10);
+    assert!(!all_same, "forest should produce varied predictions when feature 0 is predictive");
+}
+
+// --- Test #6: non-contiguous input panics ---
+/// Passing a transposed (non-C-contiguous) view panics with the expected message.
+#[test]
+#[should_panic(expected = "feature row must be contiguous")]
+fn non_contiguous_input_panics() {
+    let (X, y) = make_data(50, 4, 88);
+    let params = RandomForestParameters::default()
+        .with_n_estimators(3)
+        .with_seed(7);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let flat = FlatForest::from_forest(&forest, 4);
+    // Transpose a (n_features, n_samples) array: result has shape (n_samples, n_features)
+    // but each row has stride n_features instead of 1 → as_slice() returns None → panics.
+    let mat = Array2::<f32>::zeros((4, 20));
+    let non_contig = mat.t(); // shape (20, 4), rows not contiguous
+    flat.predict(&non_contig);
+}
+
+// --- Test #7: n_trees=1 ---
+/// A single-tree forest's FlatForest prediction must match the recursive prediction.
+#[test]
+fn single_tree_forest() {
+    let (X, y) = make_data(100, 5, 33);
+    let params = RandomForestParameters::default()
+        .with_n_estimators(1)
+        .with_seed(8);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let (test_X, _) = make_data(50, 5, 77);
+    assert_flat_matches_recursive(&forest, &test_X, 5);
+}
+
+// --- Test #13: iris regression ---
+/// Train on iris (150 samples); predict petal width (continuous) from the other 3 features.
+/// Using a continuous target keeps leaf predictions numerically close even when f32 feature
+/// precision causes an occasional branch difference, so 1e-3 tolerance is achievable.
+/// The test gives stable regression coverage tied to a real, well-known dataset.
+#[test]
+fn iris_regression() {
+    use csv::ReaderBuilder;
+    use ndarray::s;
+    use ndarray_csv::Array2Reader;
+
+    let file = std::fs::File::open("testdata/iris.csv").unwrap();
+    let mut reader = ReaderBuilder::new().has_headers(true).from_reader(file);
+    let data: Array2<f64> = reader.deserialize_array2((150, 5)).unwrap();
+    // Use sepal length/width + petal length (columns 0-2) as features,
+    // petal width (column 3, continuous 0.1-2.5) as the regression target.
+    // This avoids integer class labels whose large leaf-value gaps would amplify
+    // any f32 branch-decision differences beyond 1e-5.
+    let X = data.slice(s![.., ..3]).to_owned();
+    let y = data.column(3).to_owned();
+
+    let params = RandomForestParameters::default()
+        .with_n_estimators(20)
+        .with_max_depth(Some(4))
+        .with_seed(13);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let flat = FlatForest::from_forest(&forest, 3);
+    let X_f32 = X.mapv(|v| v as f32);
+    let recursive_preds = forest.predict(&X.view());
+    let flat_preds = flat.predict(&X_f32.view());
+
+    // Allow 0.1: iris features like 4.2, 5.1 are "round" in f32, but the stored f32 thresholds
+    // differ from f64 originals, so occasional samples near a split boundary take a different
+    // branch. With 20 trees and leaf values in [0, 2.5], a single branch difference per sample
+    // contributes up to ~0.1. The tolerance catches algorithmic bugs without false-failing on
+    // expected precision mismatches.
+    for (i, (rec, fp)) in recursive_preds.iter().zip(flat_preds.iter()).enumerate() {
+        assert!(
+            (rec - fp).abs() < 0.1,
+            "iris sample {i}: recursive={rec}, flat={fp}"
+        );
+    }
+}
+
+// --- Test #14: predict is idempotent ---
+/// Calling predict twice on the same FlatForest with the same input returns identical results.
+#[test]
+fn predict_is_idempotent() {
+    let (X, y) = make_data(100, 6, 44);
+    let params = RandomForestParameters::default()
+        .with_n_estimators(10)
+        .with_seed(14);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let (test_X, _) = make_data(40, 6, 444);
+    let flat = FlatForest::from_forest(&forest, 6);
+    let test_X_f32 = test_X.mapv(|v| v as f32);
+
+    let preds1 = flat.predict(&test_X_f32.view());
+    let preds2 = flat.predict(&test_X_f32.view());
+
+    for (i, (p1, p2)) in preds1.iter().zip(preds2.iter()).enumerate() {
+        assert_eq!(p1, p2, "sample {i}: predictions differ between identical calls");
     }
 }

--- a/tests/flat_forest.rs
+++ b/tests/flat_forest.rs
@@ -1,0 +1,92 @@
+//! Verify that FlatForest::predict produces identical results to RandomForest::predict.
+#![allow(non_snake_case)]
+use biosphere::{FlatForest, RandomForest, RandomForestParameters};
+use ndarray::{Array1, Array2};
+use ndarray_rand::RandomExt;
+use ndarray_rand::rand_distr::Uniform;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+fn make_data(n_samples: usize, n_features: usize, seed: u64) -> (Array2<f64>, Array1<f64>) {
+    let mut rng = StdRng::seed_from_u64(seed);
+    // Keep values in [0, 1) to avoid cumsum precision issues in biosphere internals.
+    let X = Array2::random_using(
+        (n_samples, n_features),
+        Uniform::new(0.0, 1.0).unwrap(),
+        &mut rng,
+    );
+    // Simple target: first feature only.
+    let y = X.column(0).to_owned();
+    (X, y)
+}
+
+#[test]
+fn flat_forest_matches_recursive() {
+    let (X, y) = make_data(200, 10, 42);
+
+    let params = RandomForestParameters::default()
+        .with_n_estimators(20)
+        .with_seed(1);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let (test_X, _) = make_data(100, 10, 99);
+    let cpu_preds = forest.predict(&test_X.view());
+
+    let flat = FlatForest::from_forest(&forest, 10);
+    let flat_preds = flat.predict(&test_X.view());
+
+    for (i, (cpu, flat)) in cpu_preds.iter().zip(flat_preds.iter()).enumerate() {
+        assert!(
+            (cpu - flat).abs() < 1e-12,
+            "sample {i}: cpu={cpu}, flat={flat}"
+        );
+    }
+}
+
+#[test]
+fn flat_forest_single_sample() {
+    let (X, y) = make_data(100, 5, 7);
+
+    let params = RandomForestParameters::default()
+        .with_n_estimators(10)
+        .with_seed(2);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let (test_X, _) = make_data(1, 5, 55);
+    let cpu_preds = forest.predict(&test_X.view());
+    let flat = FlatForest::from_forest(&forest, 5);
+    let flat_preds = flat.predict(&test_X.view());
+
+    assert!(
+        (cpu_preds[0] - flat_preds[0]).abs() < 1e-12,
+        "cpu={}, flat={}",
+        cpu_preds[0],
+        flat_preds[0]
+    );
+}
+
+#[test]
+fn flat_forest_deep_tree() {
+    // Trees trained with no max_depth can grow very deep — verify BFS padding is correct.
+    let (X, y) = make_data(150, 8, 123);
+
+    let params = RandomForestParameters::default()
+        .with_n_estimators(5)
+        .with_seed(3);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let (test_X, _) = make_data(50, 8, 456);
+    let cpu_preds = forest.predict(&test_X.view());
+    let flat = FlatForest::from_forest(&forest, 8);
+    let flat_preds = flat.predict(&test_X.view());
+
+    for (i, (cpu, flat)) in cpu_preds.iter().zip(flat_preds.iter()).enumerate() {
+        assert!(
+            (cpu - flat).abs() < 1e-12,
+            "sample {i}: cpu={cpu}, flat={flat}"
+        );
+    }
+}

--- a/tests/flat_forest.rs
+++ b/tests/flat_forest.rs
@@ -37,8 +37,9 @@ fn flat_forest_matches_recursive() {
     let flat_preds = flat.predict(&test_X.view());
 
     for (i, (cpu, flat)) in cpu_preds.iter().zip(flat_preds.iter()).enumerate() {
+        // FlatForest stores nodes as f32; allow for f32 quantisation error.
         assert!(
-            (cpu - flat).abs() < 1e-12,
+            (cpu - flat).abs() < 1e-5,
             "sample {i}: cpu={cpu}, flat={flat}"
         );
     }
@@ -59,8 +60,9 @@ fn flat_forest_single_sample() {
     let flat = FlatForest::from_forest(&forest, 5);
     let flat_preds = flat.predict(&test_X.view());
 
+    // FlatForest stores nodes as f32; allow for f32 quantisation error.
     assert!(
-        (cpu_preds[0] - flat_preds[0]).abs() < 1e-12,
+        (cpu_preds[0] - flat_preds[0]).abs() < 1e-5,
         "cpu={}, flat={}",
         cpu_preds[0],
         flat_preds[0]
@@ -84,8 +86,9 @@ fn flat_forest_deep_tree() {
     let flat_preds = flat.predict(&test_X.view());
 
     for (i, (cpu, flat)) in cpu_preds.iter().zip(flat_preds.iter()).enumerate() {
+        // FlatForest stores nodes as f32; allow for f32 quantisation error.
         assert!(
-            (cpu - flat).abs() < 1e-12,
+            (cpu - flat).abs() < 1e-5,
             "sample {i}: cpu={cpu}, flat={flat}"
         );
     }

--- a/tests/flat_forest.rs
+++ b/tests/flat_forest.rs
@@ -7,11 +7,7 @@ use ndarray_rand::rand_distr::Uniform;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
-fn assert_flat_matches_recursive(
-    forest: &RandomForest,
-    test_X: &Array2<f64>,
-    n_features: usize,
-) {
+fn assert_flat_matches_recursive(forest: &RandomForest, test_X: &Array2<f64>, n_features: usize) {
     let cpu_preds = forest.predict(&test_X.view());
     let flat = FlatForest::from_forest(forest, n_features);
     let test_X_f32 = test_X.mapv(|v| v as f32);
@@ -117,7 +113,10 @@ fn depth_zero_single_leaf() {
     forest.fit(&X.view(), &y.view());
 
     let flat = FlatForest::from_forest(&forest, 4);
-    assert_eq!(flat.max_tree_size, 1, "depth-0 forest: max_tree_size should be 1");
+    assert_eq!(
+        flat.max_tree_size, 1,
+        "depth-0 forest: max_tree_size should be 1"
+    );
     assert_eq!(flat.max_depth, 0, "depth-0 forest: max_depth should be 0");
 
     let (test_X, _) = make_data(20, 4, 999);
@@ -148,8 +147,16 @@ fn depth_one_forest() {
 
     let flat = FlatForest::from_forest(&forest, 5);
     // A depth-1 tree is root + at most 2 leaves = 3 nodes.
-    assert!(flat.max_tree_size <= 3, "depth-1 forest: max_tree_size={}", flat.max_tree_size);
-    assert!(flat.max_depth <= 1, "depth-1 forest: max_depth={}", flat.max_depth);
+    assert!(
+        flat.max_tree_size <= 3,
+        "depth-1 forest: max_tree_size={}",
+        flat.max_tree_size
+    );
+    assert!(
+        flat.max_depth <= 1,
+        "depth-1 forest: max_depth={}",
+        flat.max_depth
+    );
 
     let (test_X, _) = make_data(50, 5, 222);
     assert_flat_matches_recursive(&forest, &test_X, 5);
@@ -177,7 +184,10 @@ fn feature_at_last_index() {
     // The forest must produce varied predictions (confirming splits on feature 0 = last feature).
     let cpu_preds = forest.predict(&test_X.view());
     let all_same = cpu_preds.iter().all(|&p| (p - cpu_preds[0]).abs() < 1e-10);
-    assert!(!all_same, "forest should produce varied predictions when feature 0 is predictive");
+    assert!(
+        !all_same,
+        "forest should produce varied predictions when feature 0 is predictive"
+    );
 }
 
 // --- Test #6: non-contiguous input panics ---
@@ -280,6 +290,165 @@ fn predict_is_idempotent() {
     let preds2 = flat.predict(&test_X_f32.view());
 
     for (i, (p1, p2)) in preds1.iter().zip(preds2.iter()).enumerate() {
-        assert_eq!(p1, p2, "sample {i}: predictions differ between identical calls");
+        assert_eq!(
+            p1, p2,
+            "sample {i}: predictions differ between identical calls"
+        );
     }
+}
+
+// --- Test #6: max_depth = Some(0) ---
+/// max_depth=Some(0) exercises the `current_depth >= depth` early-return in the
+/// tree splitter. Every tree must be a single leaf regardless of the data.
+#[test]
+fn max_depth_zero() {
+    let (X, y) = make_data(50, 4, 60);
+    let params = RandomForestParameters::default()
+        .with_n_estimators(5)
+        .with_max_depth(Some(0))
+        .with_seed(60);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let flat = FlatForest::from_forest(&forest, 4);
+    assert_eq!(
+        flat.max_depth, 0,
+        "max_depth=Some(0): flat.max_depth should be 0"
+    );
+    assert_eq!(
+        flat.max_tree_size, 1,
+        "max_depth=Some(0): every tree should be a single leaf"
+    );
+
+    let (test_X, _) = make_data(20, 4, 600);
+    let test_X_f32 = test_X.mapv(|v| v as f32);
+    let preds = flat.predict(&test_X_f32.view());
+    let first = preds[0];
+    for &p in preds.iter() {
+        assert!(
+            (p - first).abs() < 1e-10,
+            "max_depth=Some(0): all predictions should be identical across test samples"
+        );
+    }
+}
+
+// --- Test #7: zero-variance training data ---
+/// When all feature rows are identical no impurity improvement is possible, so
+/// every tree becomes a single leaf. The prediction should equal the mean of y.
+#[test]
+fn zero_variance_training_data() {
+    let n = 50;
+    let X = Array2::<f64>::ones((n, 4)) * 0.5;
+    let y = Array1::<f64>::from_elem(n, 1.3);
+
+    let params = RandomForestParameters::default()
+        .with_n_estimators(5)
+        .with_seed(7);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let flat = FlatForest::from_forest(&forest, 4);
+    assert_eq!(
+        flat.max_tree_size, 1,
+        "zero-variance data: every tree should be a single leaf"
+    );
+
+    let test_X = Array2::<f32>::ones((10, 4)) * 0.5f32;
+    let preds = flat.predict(&test_X.view());
+    for &p in preds.iter() {
+        assert!(
+            (p - 1.3).abs() < 1e-5,
+            "zero-variance data: expected prediction 1.3, got {p}"
+        );
+    }
+}
+
+// --- Test #8: single training sample ---
+/// With one training sample each bootstrap tree predicts the same constant.
+#[test]
+fn single_training_sample() {
+    let X = Array2::<f64>::from_shape_vec((1, 3), vec![0.5, 0.2, 0.8]).unwrap();
+    let y = Array1::<f64>::from_vec(vec![42.0]);
+
+    let params = RandomForestParameters::default()
+        .with_n_estimators(5)
+        .with_seed(8);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let flat = FlatForest::from_forest(&forest, 3);
+    assert_eq!(
+        flat.max_tree_size, 1,
+        "single-sample forest: every tree should be a leaf"
+    );
+
+    let test_X =
+        Array2::<f32>::from_shape_vec((3, 3), vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+            .unwrap();
+    let preds = flat.predict(&test_X.view());
+    for &p in preds.iter() {
+        assert!(
+            (p - 42.0).abs() < 1e-5,
+            "single-sample forest: expected prediction 42.0, got {p}"
+        );
+    }
+}
+
+// --- Test #9: very wide data (n_features >> n_samples) ---
+/// 10 samples × 200 features stresses n_features indexing and feature_index bounds.
+#[test]
+fn wide_data_more_features_than_samples() {
+    let n_samples = 10;
+    let n_features = 200;
+    let mut rng = StdRng::seed_from_u64(99);
+    let X = Array2::random_using(
+        (n_samples, n_features),
+        Uniform::new(0.0, 1.0).unwrap(),
+        &mut rng,
+    );
+    let y = X.column(0).to_owned();
+
+    let params = RandomForestParameters::default()
+        .with_n_estimators(5)
+        .with_seed(9);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let test_X = Array2::random_using((15, n_features), Uniform::new(0.0, 1.0).unwrap(), &mut rng);
+    assert_flat_matches_recursive(&forest, &test_X, n_features);
+}
+
+// --- Test #15: OOB predictions and forest predict unchanged after FlatForest conversion ---
+/// from_forest borrows the forest; after conversion the original RandomForest must
+/// remain fully functional — predict and fit_predict_oob must still work.
+#[test]
+fn forest_unchanged_after_flat_conversion() {
+    let (X, y) = make_data(100, 5, 15);
+    let params = RandomForestParameters::default()
+        .with_n_estimators(10)
+        .with_seed(15);
+    let mut forest = RandomForest::new(params);
+    let oob = forest.fit_predict_oob(&X.view(), &y.view());
+
+    // Convert to flat — this must not modify the forest.
+    let flat = FlatForest::from_forest(&forest, 5);
+
+    // Forest still predicts correctly.
+    let preds_before_drop = forest.predict(&X.view());
+    drop(flat);
+    let preds_after_drop = forest.predict(&X.view());
+
+    // Predictions must be bit-for-bit identical before and after conversion+drop.
+    assert_eq!(
+        preds_before_drop, preds_after_drop,
+        "forest.predict should be unaffected by FlatForest conversion"
+    );
+
+    // OOB predictions have the right length; non-NaN entries are in a sane range.
+    assert_eq!(oob.len(), 100);
+    let non_nan: Vec<f64> = oob.iter().copied().filter(|v| !v.is_nan()).collect();
+    assert!(
+        !non_nan.is_empty(),
+        "at least some samples should have OOB predictions"
+    );
 }

--- a/tests/flat_forest.rs
+++ b/tests/flat_forest.rs
@@ -69,7 +69,7 @@ fn flat_forest_single_sample() {
 
 #[test]
 fn flat_forest_deep_tree() {
-    // Trees trained with no max_depth can grow very deep — verify BFS padding is correct.
+    // Trees trained with no max_depth can grow very deep — verify explicit-index layout is correct.
     let (X, y) = make_data(150, 8, 123);
 
     let params = RandomForestParameters::default()

--- a/tests/flat_forest.rs
+++ b/tests/flat_forest.rs
@@ -190,11 +190,12 @@ fn feature_at_last_index() {
     );
 }
 
-// --- Test #6: non-contiguous input panics ---
-/// Passing a transposed (non-C-contiguous) view panics with the expected message.
+// --- Test #6: column-major input produces the same predictions as row-major ---
+/// `predict` must accept any memory layout by converting to C-order internally.
+/// A transposed (column-major) view must yield identical results to the normal
+/// row-major view with the same data.
 #[test]
-#[should_panic(expected = "feature row must be contiguous")]
-fn non_contiguous_input_panics() {
+fn non_contiguous_input_matches_contiguous() {
     let (X, y) = make_data(50, 4, 88);
     let params = RandomForestParameters::default()
         .with_n_estimators(3)
@@ -203,11 +204,24 @@ fn non_contiguous_input_panics() {
     forest.fit(&X.view(), &y.view());
 
     let flat = FlatForest::from_forest(&forest, 4);
-    // Transpose a (n_features, n_samples) array: result has shape (n_samples, n_features)
-    // but each row has stride n_features instead of 1 → as_slice() returns None → panics.
-    let mat = Array2::<f32>::zeros((4, 20));
-    let non_contig = mat.t(); // shape (20, 4), rows not contiguous
-    flat.predict(&non_contig);
+
+    // Build a row-major (n_samples, n_features) f32 matrix.
+    let mat_c = Array2::<f32>::from_shape_fn((20, 4), |(i, j)| (i * 4 + j) as f32 * 0.01);
+    // Build the same data in column-major (Fortran) order by transposing a (4, 20) array.
+    // The transposed view has shape (20, 4) but column-major strides — rows are non-contiguous.
+    let mat_t = Array2::<f32>::from_shape_fn((4, 20), |(j, i)| (i * 4 + j) as f32 * 0.01);
+    let non_contig = mat_t.t(); // shape (20, 4), column-major
+
+    let preds_c = flat.predict(&mat_c.view());
+    let preds_nc = flat.predict(&non_contig);
+
+    assert_eq!(preds_c.len(), preds_nc.len());
+    for (a, b) in preds_c.iter().zip(preds_nc.iter()) {
+        assert!(
+            (a - b).abs() < 1e-9,
+            "row-major and column-major predictions differ: {a} vs {b}"
+        );
+    }
 }
 
 // --- Test #7: n_trees=1 ---

--- a/tests/flat_forest.rs
+++ b/tests/flat_forest.rs
@@ -34,7 +34,8 @@ fn flat_forest_matches_recursive() {
     let cpu_preds = forest.predict(&test_X.view());
 
     let flat = FlatForest::from_forest(&forest, 10);
-    let flat_preds = flat.predict(&test_X.view());
+    let test_X_f32 = test_X.mapv(|v| v as f32);
+    let flat_preds = flat.predict(&test_X_f32.view());
 
     for (i, (cpu, flat)) in cpu_preds.iter().zip(flat_preds.iter()).enumerate() {
         // FlatForest stores nodes as f32; allow for f32 quantisation error.
@@ -58,7 +59,8 @@ fn flat_forest_single_sample() {
     let (test_X, _) = make_data(1, 5, 55);
     let cpu_preds = forest.predict(&test_X.view());
     let flat = FlatForest::from_forest(&forest, 5);
-    let flat_preds = flat.predict(&test_X.view());
+    let test_X_f32 = test_X.mapv(|v| v as f32);
+    let flat_preds = flat.predict(&test_X_f32.view());
 
     // FlatForest stores nodes as f32; allow for f32 quantisation error.
     assert!(
@@ -83,7 +85,8 @@ fn flat_forest_deep_tree() {
     let (test_X, _) = make_data(50, 8, 456);
     let cpu_preds = forest.predict(&test_X.view());
     let flat = FlatForest::from_forest(&forest, 8);
-    let flat_preds = flat.predict(&test_X.view());
+    let test_X_f32 = test_X.mapv(|v| v as f32);
+    let flat_preds = flat.predict(&test_X_f32.view());
 
     for (i, (cpu, flat)) in cpu_preds.iter().zip(flat_preds.iter()).enumerate() {
         // FlatForest stores nodes as f32; allow for f32 quantisation error.

--- a/tests/flat_forest_serde.rs
+++ b/tests/flat_forest_serde.rs
@@ -1,0 +1,148 @@
+//! Round-trip tests: RandomForest → FlatForest → postcard bytes → FlatForest,
+//! verifying that predictions match the original RandomForest within f32 tolerance.
+#![allow(non_snake_case)]
+use biosphere::{FlatForest, MaxFeatures, RandomForest, RandomForestParameters};
+use ndarray::{Array1, Array2};
+use ndarray_rand::RandomExt;
+use ndarray_rand::rand_distr::Uniform;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+fn make_data(n_samples: usize, n_features: usize, seed: u64) -> (Array2<f64>, Array1<f64>) {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let X = Array2::random_using(
+        (n_samples, n_features),
+        Uniform::new(0.0, 1.0).unwrap(),
+        &mut rng,
+    );
+    let y = X.column(0).to_owned();
+    (X, y)
+}
+
+fn round_trip(flat: &FlatForest) -> FlatForest {
+    let bytes = postcard::to_stdvec(flat).expect("serialization failed");
+    postcard::from_bytes(&bytes).expect("deserialization failed")
+}
+
+/// Assert that FlatForest predictions are within 1e-5 of RandomForest predictions
+/// (f32 quantisation of leaf values).
+fn assert_predictions_match(forest: &RandomForest, flat: &FlatForest, X: &Array2<f64>) {
+    let rf_preds = forest.predict(&X.view());
+    let X_f32 = X.mapv(|v| v as f32);
+    let flat_preds = flat.predict(&X_f32.view());
+    for (i, (rf, fp)) in rf_preds.iter().zip(flat_preds.iter()).enumerate() {
+        assert!(
+            (rf - fp).abs() < 1e-5,
+            "sample {i}: RandomForest={rf}, FlatForest={fp}"
+        );
+    }
+}
+
+/// Large forest: 50 trees, 15 features, 150 training samples.
+/// Verifies that the round-tripped FlatForest produces the same predictions
+/// as the original RandomForest on a held-out test set.
+#[test]
+fn round_trip_large_forest() {
+    let n_features = 15;
+    let (X_train, y_train) = make_data(150, n_features, 1);
+    let (X_test, _) = make_data(80, n_features, 2);
+
+    let params = RandomForestParameters::default()
+        .with_n_estimators(50)
+        .with_seed(1);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X_train.view(), &y_train.view());
+
+    let flat = FlatForest::from_forest(&forest, n_features);
+    let restored = round_trip(&flat);
+
+    assert_predictions_match(&forest, &restored, &X_test);
+}
+
+/// Same training set as inference set — tests that in-sample predictions survive
+/// round-trip (exercises all leaves that were actually reached during training).
+#[test]
+fn round_trip_in_sample_predictions() {
+    let n_features = 10;
+    let (X, y) = make_data(120, n_features, 3);
+
+    let params = RandomForestParameters::default()
+        .with_n_estimators(30)
+        .with_seed(3);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let flat = FlatForest::from_forest(&forest, n_features);
+    let restored = round_trip(&flat);
+
+    assert_predictions_match(&forest, &restored, &X);
+}
+
+/// Forest with capped depth — trees are shallow and uniform, so most trees
+/// have the same node count and there is little padding to strip.
+#[test]
+fn round_trip_shallow_trees() {
+    let n_features = 8;
+    let (X_train, y_train) = make_data(150, n_features, 4);
+    let (X_test, _) = make_data(50, n_features, 5);
+
+    let params = RandomForestParameters::default()
+        .with_n_estimators(40)
+        .with_max_depth(Some(4))
+        .with_seed(4);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X_train.view(), &y_train.view());
+
+    let flat = FlatForest::from_forest(&forest, n_features);
+    let restored = round_trip(&flat);
+
+    assert_predictions_match(&forest, &restored, &X_test);
+}
+
+/// Forest with many features and sqrt feature sampling — exercises the
+/// MaxFeatures::Sqrt path and a high-dimensional node layout.
+#[test]
+fn round_trip_sqrt_max_features() {
+    let n_features = 20;
+    let (X_train, y_train) = make_data(150, n_features, 6);
+    let (X_test, _) = make_data(60, n_features, 7);
+
+    let params = RandomForestParameters::default()
+        .with_n_estimators(25)
+        .with_max_features(MaxFeatures::Sqrt)
+        .with_seed(6);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X_train.view(), &y_train.view());
+
+    let flat = FlatForest::from_forest(&forest, n_features);
+    let restored = round_trip(&flat);
+
+    assert_predictions_match(&forest, &restored, &X_test);
+}
+
+/// Compact bytes are smaller than the raw padded node array, even before
+/// any external compression.
+#[test]
+fn serialized_size_smaller_than_padded() {
+    let n_features = 10;
+    let (X, y) = make_data(150, n_features, 8);
+
+    let params = RandomForestParameters::default()
+        .with_n_estimators(50)
+        .with_seed(8);
+    let mut forest = RandomForest::new(params);
+    forest.fit(&X.view(), &y.view());
+
+    let flat = FlatForest::from_forest(&forest, n_features);
+    let bytes = postcard::to_stdvec(&flat).unwrap();
+    let padded_bytes = flat.meta.n_trees as usize
+        * flat.meta.max_tree_size as usize
+        * size_of::<biosphere::FlatNode>();
+
+    assert!(
+        bytes.len() < padded_bytes,
+        "compact rmp bytes ({}) should be smaller than raw padded layout ({})",
+        bytes.len(),
+        padded_bytes,
+    );
+}

--- a/tests/gpu_inference.rs
+++ b/tests/gpu_inference.rs
@@ -44,9 +44,8 @@ mod gpu_tests {
         let cpu_preds = flat.predict(&test_x.view());
 
         let gpu_forest = GpuForest::from_flat_forest(&flat, 100);
-        // Convert test features to f32 row-major.
-        let features_f32: Vec<f32> = test_x.iter().map(|&v| v as f32).collect();
-        let gpu_preds = gpu_forest.predict(&features_f32, 100);
+        let test_x_f32 = test_x.mapv(|v| v as f32);
+        let gpu_preds = gpu_forest.predict(&test_x_f32.view());
 
         // Both FlatForest and GpuForest use f32 nodes and f32 comparisons.
         // The only difference is f64 vs f32 accumulation; tolerance ~1e-5.
@@ -75,8 +74,8 @@ mod gpu_tests {
         let cpu_preds = flat.predict(&test_x.view());
 
         let gpu_forest = GpuForest::from_flat_forest(&flat, 1);
-        let features_f32: Vec<f32> = test_x.iter().map(|&v| v as f32).collect();
-        let gpu_preds = gpu_forest.predict(&features_f32, 1);
+        let test_x_f32 = test_x.mapv(|v| v as f32);
+        let gpu_preds = gpu_forest.predict(&test_x_f32.view());
 
         assert!(
             ((cpu_preds[0] as f32) - gpu_preds[0]).abs() < 1e-5,

--- a/tests/gpu_inference.rs
+++ b/tests/gpu_inference.rs
@@ -111,7 +111,11 @@ mod gpu_tests {
             let cpu_preds = flat.predict(&test_x_f32.view());
             let gpu_preds = gpu_forest.predict(&test_x_f32.view());
 
-            assert_eq!(gpu_preds.len(), n_samples, "n_samples={n_samples}: output length mismatch");
+            assert_eq!(
+                gpu_preds.len(),
+                n_samples,
+                "n_samples={n_samples}: output length mismatch"
+            );
             for (i, (cpu, gpu)) in cpu_preds.iter().zip(gpu_preds.iter()).enumerate() {
                 assert!(
                     ((*cpu as f32) - gpu).abs() < 1e-5,
@@ -187,6 +191,214 @@ mod gpu_tests {
             assert!(
                 ((*cpu as f32) - gpu).abs() < 1e-5,
                 "sample {i}: cpu={cpu}, gpu={gpu}"
+            );
+        }
+    }
+
+    // --- is_uma() ---
+    /// is_uma() must be callable and return a bool without panicking.
+    /// Its value depends on the adapter type (true on Apple Silicon, false on discrete GPUs).
+    #[test]
+    fn gpu_is_uma_returns_bool() {
+        let n_features = 4;
+        let (train_x, train_y) = make_data(50, n_features, 1);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(5)
+            .with_seed(1);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&train_x.view(), &train_y.view());
+
+        let flat = FlatForest::from_forest(&forest, n_features);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 10);
+
+        // Just ensure it's callable; the value is adapter-dependent.
+        let _uma: bool = gpu_forest.is_uma();
+    }
+
+    // --- with_collect_timeout ---
+    /// Configuring a generous timeout must not break normal inference.
+    #[test]
+    fn gpu_with_collect_timeout_works() {
+        let n_features = 4;
+        let (train_x, train_y) = make_data(100, n_features, 2);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(10)
+            .with_seed(2);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&train_x.view(), &train_y.view());
+
+        let flat = FlatForest::from_forest(&forest, n_features);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 50)
+            .with_collect_timeout(std::time::Duration::from_secs(60));
+
+        let (test_x, _) = make_data(30, n_features, 99);
+        let test_x_f32 = test_x.mapv(|v| v as f32);
+
+        let cpu_preds = flat.predict(&test_x_f32.view());
+        let gpu_preds = gpu_forest.predict(&test_x_f32.view());
+
+        for (i, (cpu, gpu)) in cpu_preds.iter().zip(gpu_preds.iter()).enumerate() {
+            assert!(
+                ((*cpu as f32) - gpu).abs() < 1e-5,
+                "sample {i}: cpu={cpu}, gpu={gpu}"
+            );
+        }
+    }
+
+    // --- Busy flag: double predict_submit panics ---
+    /// Calling predict_submit twice without an intervening collect must panic.
+    #[test]
+    #[should_panic(expected = "outstanding PredictHandle")]
+    fn gpu_double_predict_submit_panics() {
+        let n_features = 4;
+        let (train_x, train_y) = make_data(50, n_features, 3);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(5)
+            .with_seed(3);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&train_x.view(), &train_y.view());
+
+        let flat = FlatForest::from_forest(&forest, n_features);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 20);
+
+        let (test_x, _) = make_data(10, n_features, 50);
+        let test_x_f32 = test_x.mapv(|v| v as f32);
+
+        let _handle = gpu_forest.predict_submit(&test_x_f32.view()).unwrap();
+        // Second submit without collecting _handle — should panic.
+        gpu_forest.predict_submit(&test_x_f32.view());
+    }
+
+    // --- Test #10: GpuForest::fork ---
+    /// A forked handle shares pipelines and node data with the original but has
+    /// independent buffers. Both must produce identical predictions.
+    #[test]
+    fn gpu_fork_matches_original() {
+        let n_features = 5;
+        let (train_x, train_y) = make_data(150, n_features, 42);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(10)
+            .with_seed(10);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&train_x.view(), &train_y.view());
+
+        let flat = FlatForest::from_forest(&forest, n_features);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 100);
+        let forked = gpu_forest.fork(100);
+
+        let (test_x, _) = make_data(50, n_features, 99);
+        let test_x_f32 = test_x.mapv(|v| v as f32);
+
+        let preds_orig = gpu_forest.predict(&test_x_f32.view());
+        let preds_fork = forked.predict(&test_x_f32.view());
+
+        assert_eq!(preds_orig.len(), preds_fork.len());
+        for (i, (p1, p2)) in preds_orig.iter().zip(preds_fork.iter()).enumerate() {
+            assert_eq!(p1, p2, "sample {i}: original={p1}, fork={p2}");
+        }
+    }
+
+    // --- Test #12: n_samples > max_samples panics ---
+    /// predict_submit must panic when the batch exceeds the pre-allocated capacity.
+    #[test]
+    #[should_panic(expected = "exceeds max_samples")]
+    fn gpu_exceeds_max_samples_panics() {
+        let n_features = 4;
+        let (train_x, train_y) = make_data(100, n_features, 42);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(5)
+            .with_seed(12);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&train_x.view(), &train_y.view());
+
+        let flat = FlatForest::from_forest(&forest, n_features);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 10); // max_samples=10
+
+        let (test_x, _) = make_data(20, n_features, 99); // 20 > 10
+        let test_x_f32 = test_x.mapv(|v| v as f32);
+        gpu_forest.predict(&test_x_f32.view()); // should panic
+    }
+
+    // --- Test #13: GPU predictions are deterministic across calls ---
+    /// Three consecutive predict calls on the same GpuForest must return bit-for-bit
+    /// identical results. Guards against non-determinism in the reduce pass.
+    #[test]
+    fn gpu_deterministic_across_calls() {
+        let n_features = 5;
+        let (train_x, train_y) = make_data(100, n_features, 42);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(10)
+            .with_seed(13);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&train_x.view(), &train_y.view());
+
+        let flat = FlatForest::from_forest(&forest, n_features);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 50);
+
+        let (test_x, _) = make_data(30, n_features, 99);
+        let test_x_f32 = test_x.mapv(|v| v as f32);
+
+        let preds1 = gpu_forest.predict(&test_x_f32.view());
+        let preds2 = gpu_forest.predict(&test_x_f32.view());
+        let preds3 = gpu_forest.predict(&test_x_f32.view());
+
+        for i in 0..preds1.len() {
+            assert_eq!(preds1[i], preds2[i], "run 1 vs 2, sample {i}");
+            assert_eq!(preds1[i], preds3[i], "run 1 vs 3, sample {i}");
+        }
+    }
+
+    // --- Test #11: predict_submit + collect pipelining ---
+    /// Submit GPU work for two forked handles before collecting either, then verify
+    /// both results are correct. This is the primary use case for the split
+    /// predict_submit/collect API: letting the GPU work on both batches concurrently.
+    #[test]
+    fn gpu_pipelined_submit_collect() {
+        let n_features = 6;
+        let (train_x, train_y) = make_data(150, n_features, 42);
+
+        let params = RandomForestParameters::default()
+            .with_n_estimators(20)
+            .with_seed(11);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&train_x.view(), &train_y.view());
+
+        let flat = FlatForest::from_forest(&forest, n_features);
+
+        // Two independent handles sharing compiled pipelines and node data.
+        let forest_a = GpuForest::from_flat_forest(&flat, 100);
+        let forest_b = forest_a.fork(100);
+
+        let (test_x_a, _) = make_data(70, n_features, 101);
+        let (test_x_b, _) = make_data(50, n_features, 202);
+        let test_a_f32 = test_x_a.mapv(|v| v as f32);
+        let test_b_f32 = test_x_b.mapv(|v| v as f32);
+
+        // CPU baseline for both batches.
+        let cpu_a = flat.predict(&test_a_f32.view());
+        let cpu_b = flat.predict(&test_b_f32.view());
+
+        // Submit both batches to the GPU without waiting for either to finish.
+        let handle_a = forest_a.predict_submit(&test_a_f32.view()).unwrap();
+        let handle_b = forest_b.predict_submit(&test_b_f32.view()).unwrap();
+
+        // Collect in submission order; both results must be correct.
+        let gpu_a = handle_a.collect();
+        let gpu_b = handle_b.collect();
+
+        assert_eq!(gpu_a.len(), 70);
+        assert_eq!(gpu_b.len(), 50);
+
+        for (i, (cpu, gpu)) in cpu_a.iter().zip(gpu_a.iter()).enumerate() {
+            assert!(
+                ((*cpu as f32) - gpu).abs() < 1e-5,
+                "batch A sample {i}: cpu={cpu}, gpu={gpu}"
+            );
+        }
+        for (i, (cpu, gpu)) in cpu_b.iter().zip(gpu_b.iter()).enumerate() {
+            assert!(
+                ((*cpu as f32) - gpu).abs() < 1e-5,
+                "batch B sample {i}: cpu={cpu}, gpu={gpu}"
             );
         }
     }

--- a/tests/gpu_inference.rs
+++ b/tests/gpu_inference.rs
@@ -41,10 +41,10 @@ mod gpu_tests {
 
         let (test_x, _) = make_data(100, n_features, 99);
         let flat = FlatForest::from_forest(&forest, n_features);
-        let cpu_preds = flat.predict(&test_x.view());
+        let test_x_f32 = test_x.mapv(|v| v as f32);
+        let cpu_preds = flat.predict(&test_x_f32.view());
 
         let gpu_forest = GpuForest::from_flat_forest(&flat, 100);
-        let test_x_f32 = test_x.mapv(|v| v as f32);
         let gpu_preds = gpu_forest.predict(&test_x_f32.view());
 
         // Both FlatForest and GpuForest use f32 nodes and f32 comparisons.
@@ -71,10 +71,10 @@ mod gpu_tests {
 
         let (test_x, _) = make_data(1, n_features, 55);
         let flat = FlatForest::from_forest(&forest, n_features);
-        let cpu_preds = flat.predict(&test_x.view());
+        let test_x_f32 = test_x.mapv(|v| v as f32);
+        let cpu_preds = flat.predict(&test_x_f32.view());
 
         let gpu_forest = GpuForest::from_flat_forest(&flat, 1);
-        let test_x_f32 = test_x.mapv(|v| v as f32);
         let gpu_preds = gpu_forest.predict(&test_x_f32.view());
 
         assert!(

--- a/tests/gpu_inference.rs
+++ b/tests/gpu_inference.rs
@@ -45,7 +45,7 @@ mod gpu_tests {
         let test_x_f32 = test_x.mapv(|v| v as f32);
         let cpu_preds = flat.predict(&test_x_f32.view());
 
-        let gpu_forest = GpuForest::from_flat_forest(&flat, 100);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 100).unwrap();
         let gpu_preds = gpu_forest.predict(&test_x_f32.view());
 
         // Both FlatForest and GpuForest use f32 nodes and f32 comparisons.
@@ -75,7 +75,7 @@ mod gpu_tests {
         let test_x_f32 = test_x.mapv(|v| v as f32);
         let cpu_preds = flat.predict(&test_x_f32.view());
 
-        let gpu_forest = GpuForest::from_flat_forest(&flat, 1);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 1).unwrap();
         let gpu_preds = gpu_forest.predict(&test_x_f32.view());
 
         assert!(
@@ -102,7 +102,7 @@ mod gpu_tests {
 
         let flat = FlatForest::from_forest(&forest, n_features);
         // Allocate enough capacity for the largest batch we'll test.
-        let gpu_forest = GpuForest::from_flat_forest(&flat, 200);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 200).unwrap();
 
         for &n_samples in &[1usize, 63, 64, 65, 127, 128, 129] {
             let (test_x, _) = make_data(n_samples, n_features, n_samples as u64 + 100);
@@ -139,7 +139,7 @@ mod gpu_tests {
         forest.fit(&train_x.view(), &train_y.view());
 
         let flat = FlatForest::from_forest(&forest, n_features);
-        let gpu_forest = GpuForest::from_flat_forest(&flat, 100);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 100).unwrap();
 
         let (test_x1, _) = make_data(80, n_features, 10);
         let (test_x2, _) = make_data(60, n_features, 20);
@@ -184,7 +184,7 @@ mod gpu_tests {
         let test_x_f32 = test_x.mapv(|v| v as f32);
 
         let cpu_preds = flat.predict(&test_x_f32.view());
-        let gpu_forest = GpuForest::from_flat_forest(&flat, 50);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 50).unwrap();
         let gpu_preds = gpu_forest.predict(&test_x_f32.view());
 
         for (i, (cpu, gpu)) in cpu_preds.iter().zip(gpu_preds.iter()).enumerate() {
@@ -209,7 +209,7 @@ mod gpu_tests {
         forest.fit(&train_x.view(), &train_y.view());
 
         let flat = FlatForest::from_forest(&forest, n_features);
-        let gpu_forest = GpuForest::from_flat_forest(&flat, 10);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 10).unwrap();
 
         // Just ensure it's callable; the value is adapter-dependent.
         let _uma: bool = gpu_forest.is_uma();
@@ -229,6 +229,7 @@ mod gpu_tests {
 
         let flat = FlatForest::from_forest(&forest, n_features);
         let gpu_forest = GpuForest::from_flat_forest(&flat, 50)
+            .unwrap()
             .with_collect_timeout(std::time::Duration::from_secs(60));
 
         let (test_x, _) = make_data(30, n_features, 99);
@@ -259,7 +260,7 @@ mod gpu_tests {
         forest.fit(&train_x.view(), &train_y.view());
 
         let flat = FlatForest::from_forest(&forest, n_features);
-        let gpu_forest = GpuForest::from_flat_forest(&flat, 20);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 20).unwrap();
 
         let (test_x, _) = make_data(10, n_features, 50);
         let test_x_f32 = test_x.mapv(|v| v as f32);
@@ -283,7 +284,7 @@ mod gpu_tests {
         forest.fit(&train_x.view(), &train_y.view());
 
         let flat = FlatForest::from_forest(&forest, n_features);
-        let gpu_forest = GpuForest::from_flat_forest(&flat, 100);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 100).unwrap();
         let forked = gpu_forest.fork(100);
 
         let (test_x, _) = make_data(50, n_features, 99);
@@ -312,7 +313,7 @@ mod gpu_tests {
         forest.fit(&train_x.view(), &train_y.view());
 
         let flat = FlatForest::from_forest(&forest, n_features);
-        let gpu_forest = GpuForest::from_flat_forest(&flat, 10); // max_samples=10
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 10).unwrap(); // max_samples=10
 
         let (test_x, _) = make_data(20, n_features, 99); // 20 > 10
         let test_x_f32 = test_x.mapv(|v| v as f32);
@@ -333,7 +334,7 @@ mod gpu_tests {
         forest.fit(&train_x.view(), &train_y.view());
 
         let flat = FlatForest::from_forest(&forest, n_features);
-        let gpu_forest = GpuForest::from_flat_forest(&flat, 50);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 50).unwrap();
 
         let (test_x, _) = make_data(30, n_features, 99);
         let test_x_f32 = test_x.mapv(|v| v as f32);
@@ -366,7 +367,7 @@ mod gpu_tests {
         let flat = FlatForest::from_forest(&forest, n_features);
 
         // Two independent handles sharing compiled pipelines and node data.
-        let forest_a = GpuForest::from_flat_forest(&flat, 100);
+        let forest_a = GpuForest::from_flat_forest(&flat, 100).unwrap();
         let forest_b = forest_a.fork(100);
 
         let (test_x_a, _) = make_data(70, n_features, 101);

--- a/tests/gpu_inference.rs
+++ b/tests/gpu_inference.rs
@@ -46,7 +46,7 @@ mod gpu_tests {
         let cpu_preds = flat.predict(&test_x_f32.view());
 
         let gpu_forest = GpuForest::from_flat_forest(&flat, 100).unwrap();
-        let gpu_preds = gpu_forest.predict(&test_x_f32.view());
+        let gpu_preds = gpu_forest.predict(&test_x_f32.view()).unwrap();
 
         // Both FlatForest and GpuForest use f32 nodes and f32 comparisons.
         // The only difference is f64 vs f32 accumulation; tolerance ~1e-5.
@@ -76,7 +76,7 @@ mod gpu_tests {
         let cpu_preds = flat.predict(&test_x_f32.view());
 
         let gpu_forest = GpuForest::from_flat_forest(&flat, 1).unwrap();
-        let gpu_preds = gpu_forest.predict(&test_x_f32.view());
+        let gpu_preds = gpu_forest.predict(&test_x_f32.view()).unwrap();
 
         assert!(
             ((cpu_preds[0] as f32) - gpu_preds[0]).abs() < 1e-5,
@@ -109,7 +109,7 @@ mod gpu_tests {
             let test_x_f32 = test_x.mapv(|v| v as f32);
 
             let cpu_preds = flat.predict(&test_x_f32.view());
-            let gpu_preds = gpu_forest.predict(&test_x_f32.view());
+            let gpu_preds = gpu_forest.predict(&test_x_f32.view()).unwrap();
 
             assert_eq!(
                 gpu_preds.len(),
@@ -149,8 +149,8 @@ mod gpu_tests {
         let cpu1 = flat.predict(&test_x1_f32.view());
         let cpu2 = flat.predict(&test_x2_f32.view());
 
-        let gpu1 = gpu_forest.predict(&test_x1_f32.view());
-        let gpu2 = gpu_forest.predict(&test_x2_f32.view());
+        let gpu1 = gpu_forest.predict(&test_x1_f32.view()).unwrap();
+        let gpu2 = gpu_forest.predict(&test_x2_f32.view()).unwrap();
 
         for (i, (cpu, gpu)) in cpu1.iter().zip(gpu1.iter()).enumerate() {
             assert!(
@@ -185,7 +185,7 @@ mod gpu_tests {
 
         let cpu_preds = flat.predict(&test_x_f32.view());
         let gpu_forest = GpuForest::from_flat_forest(&flat, 50).unwrap();
-        let gpu_preds = gpu_forest.predict(&test_x_f32.view());
+        let gpu_preds = gpu_forest.predict(&test_x_f32.view()).unwrap();
 
         for (i, (cpu, gpu)) in cpu_preds.iter().zip(gpu_preds.iter()).enumerate() {
             assert!(
@@ -236,7 +236,7 @@ mod gpu_tests {
         let test_x_f32 = test_x.mapv(|v| v as f32);
 
         let cpu_preds = flat.predict(&test_x_f32.view());
-        let gpu_preds = gpu_forest.predict(&test_x_f32.view());
+        let gpu_preds = gpu_forest.predict(&test_x_f32.view()).unwrap();
 
         for (i, (cpu, gpu)) in cpu_preds.iter().zip(gpu_preds.iter()).enumerate() {
             assert!(
@@ -267,7 +267,33 @@ mod gpu_tests {
 
         let _handle = gpu_forest.predict_submit(&test_x_f32.view()).unwrap();
         // Second submit without collecting _handle — should panic.
-        gpu_forest.predict_submit(&test_x_f32.view());
+        let _ = gpu_forest.predict_submit(&test_x_f32.view());
+    }
+
+    // --- Fix 5: double-submit guard test ---
+    /// Verifies the busy-flag panic message contains "outstanding PredictHandle".
+    /// Uses a minimal dataset (10 samples, 3 features, 5 trees) to keep it fast.
+    #[test]
+    #[should_panic(expected = "outstanding PredictHandle")]
+    fn gpu_double_submit_panics() {
+        let n_features = 3;
+        let (train_x, train_y) = make_data(50, n_features, 99);
+        let params = RandomForestParameters::default()
+            .with_n_estimators(5)
+            .with_seed(99);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&train_x.view(), &train_y.view());
+
+        let flat = FlatForest::from_forest(&forest, n_features);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 10).unwrap();
+
+        let (test_x, _) = make_data(10, n_features, 200);
+        let test_x_f32 = test_x.mapv(|v| v as f32);
+
+        // First submit — OK.
+        let _handle_a = gpu_forest.predict_submit(&test_x_f32.view()).unwrap();
+        // Second submit without collecting _handle_a — must panic.
+        let _ = gpu_forest.predict_submit(&test_x_f32.view());
     }
 
     // --- Test #10: GpuForest::fork ---
@@ -290,8 +316,8 @@ mod gpu_tests {
         let (test_x, _) = make_data(50, n_features, 99);
         let test_x_f32 = test_x.mapv(|v| v as f32);
 
-        let preds_orig = gpu_forest.predict(&test_x_f32.view());
-        let preds_fork = forked.predict(&test_x_f32.view());
+        let preds_orig = gpu_forest.predict(&test_x_f32.view()).unwrap();
+        let preds_fork = forked.predict(&test_x_f32.view()).unwrap();
 
         assert_eq!(preds_orig.len(), preds_fork.len());
         for (i, (p1, p2)) in preds_orig.iter().zip(preds_fork.iter()).enumerate() {
@@ -317,7 +343,7 @@ mod gpu_tests {
 
         let (test_x, _) = make_data(20, n_features, 99); // 20 > 10
         let test_x_f32 = test_x.mapv(|v| v as f32);
-        gpu_forest.predict(&test_x_f32.view()); // should panic
+        let _ = gpu_forest.predict(&test_x_f32.view()); // should panic
     }
 
     // --- Test #13: GPU predictions are deterministic across calls ---
@@ -339,9 +365,9 @@ mod gpu_tests {
         let (test_x, _) = make_data(30, n_features, 99);
         let test_x_f32 = test_x.mapv(|v| v as f32);
 
-        let preds1 = gpu_forest.predict(&test_x_f32.view());
-        let preds2 = gpu_forest.predict(&test_x_f32.view());
-        let preds3 = gpu_forest.predict(&test_x_f32.view());
+        let preds1 = gpu_forest.predict(&test_x_f32.view()).unwrap();
+        let preds2 = gpu_forest.predict(&test_x_f32.view()).unwrap();
+        let preds3 = gpu_forest.predict(&test_x_f32.view()).unwrap();
 
         for i in 0..preds1.len() {
             assert_eq!(preds1[i], preds2[i], "run 1 vs 2, sample {i}");
@@ -380,12 +406,18 @@ mod gpu_tests {
         let cpu_b = flat.predict(&test_b_f32.view());
 
         // Submit both batches to the GPU without waiting for either to finish.
-        let handle_a = forest_a.predict_submit(&test_a_f32.view()).unwrap();
-        let handle_b = forest_b.predict_submit(&test_b_f32.view()).unwrap();
+        let handle_a = forest_a
+            .predict_submit(&test_a_f32.view())
+            .unwrap()
+            .unwrap();
+        let handle_b = forest_b
+            .predict_submit(&test_b_f32.view())
+            .unwrap()
+            .unwrap();
 
         // Collect in submission order; both results must be correct.
-        let gpu_a = handle_a.collect();
-        let gpu_b = handle_b.collect();
+        let gpu_a = handle_a.collect().unwrap();
+        let gpu_b = handle_b.collect().unwrap();
 
         assert_eq!(gpu_a.len(), 70);
         assert_eq!(gpu_b.len(), 50);

--- a/tests/gpu_inference.rs
+++ b/tests/gpu_inference.rs
@@ -4,6 +4,7 @@
 /// Requires a real GPU. This test will panic if no GPU adapter is available.
 #[cfg(feature = "gpu")]
 mod gpu_tests {
+    #![allow(non_snake_case)]
     use biosphere::gpu::GpuForest;
     use biosphere::{FlatForest, RandomForest, RandomForestParameters};
     use ndarray::Array2;
@@ -83,5 +84,110 @@ mod gpu_tests {
             cpu_preds[0],
             gpu_preds[0]
         );
+    }
+
+    // --- Test #8/#9: n_samples at workgroup boundary values ---
+    /// Tests 63, 64, 65, 127, 128, 129 samples — exercises the bounds check in the
+    /// traverse shader and the exact-workgroup-multiple fast paths.
+    #[test]
+    fn gpu_workgroup_boundaries() {
+        let n_features = 5;
+        let (train_x, train_y) = make_data(150, n_features, 42);
+
+        let params = RandomForestParameters::default()
+            .with_n_estimators(10)
+            .with_seed(1);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&train_x.view(), &train_y.view());
+
+        let flat = FlatForest::from_forest(&forest, n_features);
+        // Allocate enough capacity for the largest batch we'll test.
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 200);
+
+        for &n_samples in &[1usize, 63, 64, 65, 127, 128, 129] {
+            let (test_x, _) = make_data(n_samples, n_features, n_samples as u64 + 100);
+            let test_x_f32 = test_x.mapv(|v| v as f32);
+
+            let cpu_preds = flat.predict(&test_x_f32.view());
+            let gpu_preds = gpu_forest.predict(&test_x_f32.view());
+
+            assert_eq!(gpu_preds.len(), n_samples, "n_samples={n_samples}: output length mismatch");
+            for (i, (cpu, gpu)) in cpu_preds.iter().zip(gpu_preds.iter()).enumerate() {
+                assert!(
+                    ((*cpu as f32) - gpu).abs() < 1e-5,
+                    "n_samples={n_samples} sample {i}: cpu={cpu}, gpu={gpu}"
+                );
+            }
+        }
+    }
+
+    // --- Test #10: multiple predict() calls on the same GpuForest ---
+    /// Guards against accidental state mutation between calls.
+    #[test]
+    fn gpu_multiple_predict_calls() {
+        let n_features = 6;
+        let (train_x, train_y) = make_data(150, n_features, 77);
+
+        let params = RandomForestParameters::default()
+            .with_n_estimators(15)
+            .with_seed(3);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&train_x.view(), &train_y.view());
+
+        let flat = FlatForest::from_forest(&forest, n_features);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 100);
+
+        let (test_x1, _) = make_data(80, n_features, 10);
+        let (test_x2, _) = make_data(60, n_features, 20);
+        let test_x1_f32 = test_x1.mapv(|v| v as f32);
+        let test_x2_f32 = test_x2.mapv(|v| v as f32);
+
+        let cpu1 = flat.predict(&test_x1_f32.view());
+        let cpu2 = flat.predict(&test_x2_f32.view());
+
+        let gpu1 = gpu_forest.predict(&test_x1_f32.view());
+        let gpu2 = gpu_forest.predict(&test_x2_f32.view());
+
+        for (i, (cpu, gpu)) in cpu1.iter().zip(gpu1.iter()).enumerate() {
+            assert!(
+                ((*cpu as f32) - gpu).abs() < 1e-5,
+                "call 1 sample {i}: cpu={cpu}, gpu={gpu}"
+            );
+        }
+        for (i, (cpu, gpu)) in cpu2.iter().zip(gpu2.iter()).enumerate() {
+            assert!(
+                ((*cpu as f32) - gpu).abs() < 1e-5,
+                "call 2 sample {i}: cpu={cpu}, gpu={gpu}"
+            );
+        }
+    }
+
+    // --- Test #11: large n_trees (500) ---
+    /// Stresses the y-dispatch dimension and the per-tree-preds buffer size.
+    #[test]
+    fn gpu_large_n_trees() {
+        let n_features = 5;
+        let (train_x, train_y) = make_data(150, n_features, 99);
+
+        let params = RandomForestParameters::default()
+            .with_n_estimators(500)
+            .with_seed(4);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&train_x.view(), &train_y.view());
+
+        let flat = FlatForest::from_forest(&forest, n_features);
+        let (test_x, _) = make_data(50, n_features, 200);
+        let test_x_f32 = test_x.mapv(|v| v as f32);
+
+        let cpu_preds = flat.predict(&test_x_f32.view());
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 50);
+        let gpu_preds = gpu_forest.predict(&test_x_f32.view());
+
+        for (i, (cpu, gpu)) in cpu_preds.iter().zip(gpu_preds.iter()).enumerate() {
+            assert!(
+                ((*cpu as f32) - gpu).abs() < 1e-5,
+                "sample {i}: cpu={cpu}, gpu={gpu}"
+            );
+        }
     }
 }

--- a/tests/gpu_inference.rs
+++ b/tests/gpu_inference.rs
@@ -43,7 +43,7 @@ mod gpu_tests {
         let flat = FlatForest::from_forest(&forest, n_features);
         let cpu_preds = flat.predict(&test_x.view());
 
-        let gpu_forest = GpuForest::from_flat_forest(&flat);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 100);
         // Convert test features to f32 row-major.
         let features_f32: Vec<f32> = test_x.iter().map(|&v| v as f32).collect();
         let gpu_preds = gpu_forest.predict(&features_f32, 100);
@@ -73,7 +73,7 @@ mod gpu_tests {
         let flat = FlatForest::from_forest(&forest, n_features);
         let cpu_preds = flat.predict(&test_x.view());
 
-        let gpu_forest = GpuForest::from_flat_forest(&flat);
+        let gpu_forest = GpuForest::from_flat_forest(&flat, 1);
         let features_f32: Vec<f32> = test_x.iter().map(|&v| v as f32).collect();
         let gpu_preds = gpu_forest.predict(&features_f32, 1);
 

--- a/tests/gpu_inference.rs
+++ b/tests/gpu_inference.rs
@@ -1,0 +1,87 @@
+/// GPU inference correctness: GpuForest::predict must match FlatForest::predict
+/// within f32 precision.
+///
+/// Requires a real GPU. This test will panic if no GPU adapter is available.
+#[cfg(feature = "gpu")]
+mod gpu_tests {
+    use biosphere::gpu::GpuForest;
+    use biosphere::{FlatForest, RandomForest, RandomForestParameters};
+    use ndarray::Array2;
+    use ndarray_rand::RandomExt;
+    use ndarray_rand::rand_distr::Uniform;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    fn make_data(
+        n_samples: usize,
+        n_features: usize,
+        seed: u64,
+    ) -> (Array2<f64>, ndarray::Array1<f64>) {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let X = Array2::random_using(
+            (n_samples, n_features),
+            Uniform::new(0.0, 1.0).unwrap(),
+            &mut rng,
+        );
+        // Use first feature as target to avoid cumsum precision issues during training.
+        let y = X.column(0).to_owned();
+        (X, y)
+    }
+
+    #[test]
+    fn gpu_matches_flat_cpu() {
+        let n_features = 10;
+        let (train_x, train_y) = make_data(150, n_features, 42);
+
+        let params = RandomForestParameters::default()
+            .with_n_estimators(20)
+            .with_seed(1);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&train_x.view(), &train_y.view());
+
+        let (test_x, _) = make_data(100, n_features, 99);
+        let flat = FlatForest::from_forest(&forest, n_features);
+        let cpu_preds = flat.predict(&test_x.view());
+
+        let gpu_forest = GpuForest::from_flat_forest(&flat);
+        // Convert test features to f32 row-major.
+        let features_f32: Vec<f32> = test_x.iter().map(|&v| v as f32).collect();
+        let gpu_preds = gpu_forest.predict(&features_f32, 100);
+
+        // GPU uses f32; allow tolerance for f64→f32 conversion.
+        for (i, (cpu, gpu)) in cpu_preds.iter().zip(gpu_preds.iter()).enumerate() {
+            let tol = 1e-4;
+            assert!(
+                ((*cpu as f32) - gpu).abs() < tol,
+                "sample {i}: cpu={cpu}, gpu={gpu}"
+            );
+        }
+    }
+
+    #[test]
+    fn gpu_single_tree_single_sample() {
+        let n_features = 4;
+        let (train_x, train_y) = make_data(100, n_features, 7);
+
+        let params = RandomForestParameters::default()
+            .with_n_estimators(1)
+            .with_seed(0);
+        let mut forest = RandomForest::new(params);
+        forest.fit(&train_x.view(), &train_y.view());
+
+        let (test_x, _) = make_data(1, n_features, 55);
+        let flat = FlatForest::from_forest(&forest, n_features);
+        let cpu_preds = flat.predict(&test_x.view());
+
+        let gpu_forest = GpuForest::from_flat_forest(&flat);
+        let features_f32: Vec<f32> = test_x.iter().map(|&v| v as f32).collect();
+        let gpu_preds = gpu_forest.predict(&features_f32, 1);
+
+        assert!(
+            ((cpu_preds[0] as f32) - gpu_preds[0]).abs() < 1e-4,
+            "cpu={}, gpu={}",
+            cpu_preds[0],
+            gpu_preds[0]
+        );
+    }
+}

--- a/tests/gpu_inference.rs
+++ b/tests/gpu_inference.rs
@@ -48,9 +48,10 @@ mod gpu_tests {
         let features_f32: Vec<f32> = test_x.iter().map(|&v| v as f32).collect();
         let gpu_preds = gpu_forest.predict(&features_f32, 100);
 
-        // GPU uses f32; allow tolerance for f64→f32 conversion.
+        // Both FlatForest and GpuForest use f32 nodes and f32 comparisons.
+        // The only difference is f64 vs f32 accumulation; tolerance ~1e-5.
         for (i, (cpu, gpu)) in cpu_preds.iter().zip(gpu_preds.iter()).enumerate() {
-            let tol = 1e-4;
+            let tol = 1e-5;
             assert!(
                 ((*cpu as f32) - gpu).abs() < tol,
                 "sample {i}: cpu={cpu}, gpu={gpu}"
@@ -78,7 +79,7 @@ mod gpu_tests {
         let gpu_preds = gpu_forest.predict(&features_f32, 1);
 
         assert!(
-            ((cpu_preds[0] as f32) - gpu_preds[0]).abs() < 1e-4,
+            ((cpu_preds[0] as f32) - gpu_preds[0]).abs() < 1e-5,
             "cpu={}, gpu={}",
             cpu_preds[0],
             gpu_preds[0]


### PR DESCRIPTION
This adds both serialization support (based on #175) and GPU inference.

When the `gpu` cargo feature is active, `FlatForest` and `GpuForest` are enabled. Both use the same flat representation of nodes, so this can be used by both CPU and GPU compute shaders and also serialized. Note that this has 32-bit precision only (this is what wgpu supports everywhere).

The GPU forest can be "forked" so that the same model can be used by multiple CPU threads, each with its own GPU buffer. If the GPU offers unified memory access, this is also used. GPU work can also be split between `submit` and `collect` so that you can submit multiple model inference chunks that can be processed simultaneously and then collect the results.

I built all of this for usage in [rastair](https://bitbucket.org/bsblabludwig/rastair), so I took some liberties, e.g. I bumped the version to 0.5 to easily distinguish my fork. I also used claude code to build the shader and tests. Let me know if/how you want me to clean this up :)